### PR TITLE
Update flow parcel image

### DIFF
--- a/roles/FLOW01/templates/composes/FLOW01-compose.yml.j2
+++ b/roles/FLOW01/templates/composes/FLOW01-compose.yml.j2
@@ -48,7 +48,7 @@ services:
       - "{{ certs_directory }}/:{{ certs_directory }}/"
   
   SDK-FLOW:
-    image: "{{ docker_account }}/korp.flow-frontend-package:1.1.x{{ docker_image_suffix }}"
+    image: "{{ docker_account }}/sdk.flow-parcel:1.1.x{{ docker_image_suffix }}"
     container_name: "SDK.FLOW"
     restart: unless-stopped
     extra_hosts: *default-extra_hosts


### PR DESCRIPTION
The new parcel image was based on the latest flow's release/1.1.x build
"docker.io/korp/sdk.flow-parcel:1.1.88"