### PR TITLE
SD-39285-25.1

### DIFF
--- a/inventory-playbook.yml
+++ b/inventory-playbook.yml
@@ -465,6 +465,11 @@
         https_port: "{{ custom_setup_info.https_port }}"
       when: custom_setup_info.https_port != ''
 
+    - name: Definição de http_use_secure_only_tls_protocols
+      ansible.builtin.set_fact:
+        http_use_secure_only_tls_protocols: "{{ custom_setup_info.http_use_secure_only_tls_protocols | bool }}"
+      when: custom_setup_info.http_use_secure_only_tls_protocols | default('') | length > 0
+
     - name: Definição de nova senha aleatória para postgres
       ansible.builtin.set_fact:
         postgres_new_pass: "{{ lookup('community.general.random_string', length=16, special=False) }}"
@@ -573,7 +578,7 @@
               'api_gateway': shrink_inventory.dns.api_gateway | default (dns_api_gateway, true)
             },
             'https_port': shrink_inventory.https_port | default (https_port) | string,
-            'http_use_secure_only_tls_protocols': shrink_inventory.http_use_secure_only_tls_protocols | default (custom_setup_info.http_use_secure_only_tls_protocols | bool),
+            'http_use_secure_only_tls_protocols': http_use_secure_only_tls_protocols | default (shrink_inventory.http_use_secure_only_tls_protocols | default (false)),
             'reverse_proxy': {
               'external': reverse_proxy.external | default (custom_setup_info.external_reverse_proxy),
               'use_local_for_containers': reverse_proxy.use_local_for_containers | default (true),

--- a/inventory-playbook.yml
+++ b/inventory-playbook.yml
@@ -48,6 +48,7 @@
         api_gateway: ""
       configure_api_gateway_dns: false # variavel pode ser alterada pelo setup.sh obrigando a configuração do DNS api-gateway.
       https_port: ""
+      http_use_secure_only_tls_protocols: false
       external_reverse_proxy: false
       use_servergc: false
       expose_postgres: false
@@ -572,6 +573,7 @@
               'api_gateway': shrink_inventory.dns.api_gateway | default (dns_api_gateway, true)
             },
             'https_port': shrink_inventory.https_port | default (https_port) | string,
+            'http_use_secure_only_tls_protocols': shrink_inventory.http_use_secure_only_tls_protocols | default (custom_setup_info.http_use_secure_only_tls_protocols | bool),
             'reverse_proxy': {
               'external': reverse_proxy.external | default (custom_setup_info.external_reverse_proxy),
               'use_local_for_containers': reverse_proxy.use_local_for_containers | default (true),

--- a/roles/infrastructure/tasks/files_and_folders_setup.yml
+++ b/roles/infrastructure/tasks/files_and_folders_setup.yml
@@ -57,6 +57,19 @@
         owner: "{{ linux_korp.user }}"
         group: root
 
+    - name: Configuração de ssl_conf do nginx
+      ansible.builtin.template:
+        dest: "{{ config_dir_path }}/nginx/ssl_conf"
+        src: "configs/nginx/ssl_conf.j2"
+        owner: "{{ linux_korp.user }}"
+        group: root
+        mode: '0644'
+      register: nginx_ssl_conf_status
+
+    - name: Reinício do container nginx
+      ansible.builtin.import_tasks: nginx_restart.yml
+      when: nginx_ssl_conf_status.changed
+
     - name: Configuração e transferência de arquivos de configuração de nginx
       ansible.builtin.template:
         dest: "{{ config_dir_path }}/nginx/{{ item }}"
@@ -65,8 +78,8 @@
         group: root
         mode: '0644'
       loop:
-        - "ssl_conf"
         - "default_conf"
+
     - name: Configuração e transferência de arquivos de nginx
       ansible.builtin.template:
         dest: "{{ config_dir_path }}/nginx/conf.d/{{ item }}"

--- a/roles/infrastructure/templates/configs/nginx/ssl_conf.j2
+++ b/roles/infrastructure/templates/configs/nginx/ssl_conf.j2
@@ -1,5 +1,9 @@
 listen 443 ssl;
 
+{% if http_use_secure_only_tls_protocols %}
+ssl_protocols TLSv1.2 TLSv1.3;
+{% endif %}
+
 {% if certs.certbot_automated.certificate %}
 ssl_certificate /etc/nginx/certs/letsencrypt/live/{{ certbot_cert_name }}/fullchain.pem;
 ssl_certificate_key /etc/nginx/certs/letsencrypt/live/{{ certbot_cert_name }}/privkey.pem;

--- a/setup.sh
+++ b/setup.sh
@@ -52,6 +52,7 @@ docker_image_suffix="";
 db_suffix="";
 dns_api=""; dns_frontend=""; dns_cdn=""; dns_api_gateway="";
 https_port="";
+http_use_secure_only_tls_protocols="";
 cert_type=""; custom_cert_has_pass=""; custom_cert_path=""; certbot_email="";
 skip_salt_test=false;
 

--- a/setup.sh
+++ b/setup.sh
@@ -38,6 +38,7 @@ create_random_string() {
 #   configure_api_gateway_dns=<bool> - OPCIONAL, padrão false - Caso true obriga a configuração de dns_api_gateway no inventário
 ## HTTPS
 #   https_port="<port>" - OPCIONAL - porta usada para conectar ao portal local por https, padrão '443'
+#   http_use_secure_only_tls_protocols=<bool> - OPCIONAL, padrão false - Restringe o Nginx a TLSv1.2 e TLSv1.3
 ## Proxy reverso
 #   external_reverse_proxy=<bool> - OPCIONAL - Habilita o proxy reverso para ser feito fora do servidor de Linux
 ## Porta Postgres
@@ -210,6 +211,7 @@ cat > /tmp/vars.json <<EOF
     },
     "configure_api_gateway_dns": "$configure_api_gateway_dns",
     "https_port": "$https_port",
+    "http_use_secure_only_tls_protocols": "$http_use_secure_only_tls_protocols",
     "external_reverse_proxy": "$external_reverse_proxy",
     "use_servergc": "$use_servergc",
     "expose_postgres": "$expose_postgres"


### PR DESCRIPTION
TLSv1.0 deve ser recusado
```
openssl s_client -connect qa-hmlg.local:443 \
  -min_protocol TLSv1 -max_protocol TLSv1 \
  -cipher 'DEFAULT:@SECLEVEL=0' </dev/null 2>&1 | grep -E 'Protocol|error|alert'
```

Resultado (esperado - servidor rejeita):
`... error:0A00042E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version: ... SSL alert number 70
    Protocol  : TLSv1`

Testes realizados na qa-hmlg

Importante: o setup atualiza o arquivo ssl_conf no volume, mas não reinicia o container Nginx automaticamente. Após a execução, reiniciar/reload manualmente: