### PR TITLE
DEVO-6789: corrige inicialização do inventário de apps

### DIFF
--- a/roles/infrastructure/tasks/files_and_folders_setup.yml
+++ b/roles/infrastructure/tasks/files_and_folders_setup.yml
@@ -199,6 +199,6 @@
     group: root
     mode: '0644'
     content: |
-      unversioned:
-      versioned:
+      unversioned: []
+      versioned: {}
   when: not installed_apps_file.stat.exists

--- a/roles/utils/tasks/apps/ensure_mapping.yml
+++ b/roles/utils/tasks/apps/ensure_mapping.yml
@@ -7,6 +7,15 @@
   ansible.builtin.set_fact:
     apps_map: "{{ lookup('file', '{{ config_dir_path }}/installed_apps.yml') | from_yaml }}"
 
+
+- name: Normalização de mapeamento de apps legado
+  ansible.builtin.set_fact:
+    apps_map: >-
+      {{ apps_map | combine({
+        'unversioned': apps_map.unversioned | default([], true),
+        'versioned': apps_map.versioned | default({}, true)
+      }) }}
+
 - name: Remoção de mapeamento de serviço versionado exclusivos antigos
   block:
     - name: Definição de variáveis 1


### PR DESCRIPTION
## Correção

Corrige a inicialização de `installed_apps.yml` para usar coleções vazias válidas em vez de valores nulos.

Também normaliza inventários legados durante a leitura, preservando instalações existentes.

## Validação

- Sintaxe YAML validada.
- `git diff --check` executado.