### PR TITLE
Restore infrastructure-web historical templates

### DIFF
--- a/roles/infrastructure-web/templates/composes/2024.2.0/infrastructure-web-compose.yml.j2
+++ b/roles/infrastructure-web/templates/composes/2024.2.0/infrastructure-web-compose.yml.j2
@@ -1,0 +1,104 @@
+version: "3.8"
+
+x-extra_hosts:
+  &default-extra_hosts
+  - "db_mssql:$DB_MSSQL"
+  - "testing_db_mssql:$TESTING_DB_MSSQL"
+  - "app_server:$APP_SERVER"
+  - "{{ dns.api }}:$API_GATEWAY"
+  - "{{ dns.frontend }}:$PORTAL_GATEWAY"
+  - "{{ dns.cdn }}:$CDN_GATEWAY"
+{% if dns.api_gateway is defined and dns.api_gateway != "" %}
+  - "{{ dns.api_gateway }}:$API_GATEWAY_GATEWAY"
+{% endif %}
+
+networks:
+  servicos:
+    external:
+      name: servicos
+
+services:
+  korp-legacy-authorization-2024-2-0:
+    image: "{{ docker_account }}/korp.legacy.authorization:2024.2.0.x{{ docker_image_suffix }}"
+    container_name: "Korp.Legacy.Authorization-2024.2.0"
+    restart: always
+    extra_hosts: *default-extra_hosts
+    environment:
+      - ON_PREMISE_MODE=true
+      - USE_SERVERGC=$USE_SERVERGC
+      - URL_CONSUL=http://consul-server:8500
+      - CERT_FILE_PATH={{ containers_cert_path }}
+    volumes:
+      - "{{ certs_directory }}/:{{ certs_directory }}/"
+    networks:
+      - servicos
+
+  login-2024-2-0:
+    image: "{{ docker_account }}/viasoft.authentication-frontend:2024.2.0.x{{ docker_image_suffix }}"
+    container_name: "login-2024.2.0"
+    restart: unless-stopped
+    extra_hosts: *default-extra_hosts
+    environment:
+      - ON_PREMISE_MODE=true
+      - USE_SERVERGC=$USE_SERVERGC
+      - GATEWAY_URL={{ frontend.endpoints.gateway_url }}
+      - CDN_URL={{ frontend.endpoints.cdn_url }}
+      - FRONTEND_URL={{ frontend.endpoints.frontend_url }}
+      - CERT_FILE_PATH={{ containers_cert_path }}
+    networks:
+      - servicos
+    volumes:
+      - "{{ certs_directory }}/:{{ certs_directory }}/"
+
+  portal-2024-2-0:
+    image: "{{ docker_account }}/viasoft.portal-frontend:2024.2.0.x{{ docker_image_suffix }}"
+    container_name: "portal-2024.2.0"
+    restart: unless-stopped
+    extra_hosts: *default-extra_hosts
+    depends_on:
+      - viasoft-portal
+    environment:
+      - ON_PREMISE_MODE=true
+      - USE_SERVERGC=$USE_SERVERGC
+      - GATEWAY_URL={{ frontend.endpoints.gateway_url }}
+      - CDN_URL={{ frontend.endpoints.cdn_url }}
+      - FRONTEND_URL={{ frontend.endpoints.frontend_url }}
+      - CERT_FILE_PATH={{ containers_cert_path }}
+    volumes:
+      - "{{ certs_directory }}/:{{ certs_directory }}/"
+    networks:
+      - servicos
+
+  ADM01-2024-2-0:
+    image: "{{ docker_account }}/viasoft.administration-frontend:2024.2.0.x{{ docker_image_suffix }}"
+    container_name: "ADM01-2024.2.0"
+    restart: unless-stopped
+    extra_hosts: *default-extra_hosts
+    environment:
+      - ON_PREMISE_MODE=true
+      - USE_SERVERGC=$USE_SERVERGC
+      - GATEWAY_URL={{ frontend.endpoints.gateway_url }}
+      - CDN_URL={{ frontend.endpoints.cdn_url }}
+      - FRONTEND_URL={{ frontend.endpoints.frontend_url }}
+      - CERT_FILE_PATH={{ containers_cert_path }}
+    networks:
+      - servicos
+    volumes:
+      - "{{ certs_directory }}/:{{ certs_directory }}/"
+
+  REL01-2024-2-0:
+    image: "{{ docker_account }}/viasoft.relatorios-frontend:2024.2.0.x{{ docker_image_suffix }}"
+    container_name: "REL01-2024.2.0"
+    restart: unless-stopped
+    extra_hosts: *default-extra_hosts
+    environment:
+      - ON_PREMISE_MODE=true
+      - USE_SERVERGC=$USE_SERVERGC
+      - GATEWAY_URL={{ frontend.endpoints.gateway_url }}
+      - CDN_URL={{ frontend.endpoints.cdn_url }}
+      - FRONTEND_URL={{ frontend.endpoints.frontend_url }}
+      - CERT_FILE_PATH={{ containers_cert_path }}
+    networks:
+      - servicos
+    volumes:
+      - "{{ certs_directory }}/:{{ certs_directory }}/"

--- a/roles/infrastructure-web/templates/composes/2025.1.0/infrastructure-web-compose.yml.j2
+++ b/roles/infrastructure-web/templates/composes/2025.1.0/infrastructure-web-compose.yml.j2
@@ -1,0 +1,104 @@
+version: "3.8"
+
+x-extra_hosts:
+  &default-extra_hosts
+  - "db_mssql:$DB_MSSQL"
+  - "testing_db_mssql:$TESTING_DB_MSSQL"
+  - "app_server:$APP_SERVER"
+  - "{{ dns.api }}:$API_GATEWAY"
+  - "{{ dns.frontend }}:$PORTAL_GATEWAY"
+  - "{{ dns.cdn }}:$CDN_GATEWAY"
+{% if dns.api_gateway is defined and dns.api_gateway != "" %}
+  - "{{ dns.api_gateway }}:$API_GATEWAY_GATEWAY"
+{% endif %}
+
+networks:
+  servicos:
+    external:
+      name: servicos
+
+services:
+  korp-legacy-authorization-2025-1-0:
+    image: "{{ docker_account }}/korp.legacy.authorization:2025.1.0.x{{ docker_image_suffix }}"
+    container_name: "Korp.Legacy.Authorization-2025.1.0"
+    restart: always
+    extra_hosts: *default-extra_hosts
+    environment:
+      - ON_PREMISE_MODE=true
+      - USE_SERVERGC=$USE_SERVERGC
+      - URL_CONSUL=http://consul-server:8500
+      - CERT_FILE_PATH={{ containers_cert_path }}
+    volumes:
+      - "{{ certs_directory }}/:{{ certs_directory }}/"
+    networks:
+      - servicos
+
+  login-2025-1-0:
+    image: "{{ docker_account }}/viasoft.authentication-frontend:2025.1.0.x{{ docker_image_suffix }}"
+    container_name: "login-2025.1.0"
+    restart: unless-stopped
+    extra_hosts: *default-extra_hosts
+    environment:
+      - ON_PREMISE_MODE=true
+      - USE_SERVERGC=$USE_SERVERGC
+      - GATEWAY_URL={{ frontend.endpoints.gateway_url }}
+      - CDN_URL={{ frontend.endpoints.cdn_url }}
+      - FRONTEND_URL={{ frontend.endpoints.frontend_url }}
+      - CERT_FILE_PATH={{ containers_cert_path }}
+    networks:
+      - servicos
+    volumes:
+      - "{{ certs_directory }}/:{{ certs_directory }}/"
+
+  portal-2025-1-0:
+    image: "{{ docker_account }}/viasoft.portal-frontend:2025.1.0.x{{ docker_image_suffix }}"
+    container_name: "portal-2025.1.0"
+    restart: unless-stopped
+    extra_hosts: *default-extra_hosts
+    depends_on:
+      - viasoft-portal
+    environment:
+      - ON_PREMISE_MODE=true
+      - USE_SERVERGC=$USE_SERVERGC
+      - GATEWAY_URL={{ frontend.endpoints.gateway_url }}
+      - CDN_URL={{ frontend.endpoints.cdn_url }}
+      - FRONTEND_URL={{ frontend.endpoints.frontend_url }}
+      - CERT_FILE_PATH={{ containers_cert_path }}
+    volumes:
+      - "{{ certs_directory }}/:{{ certs_directory }}/"
+    networks:
+      - servicos
+
+  ADM01-2025-1-0:
+    image: "{{ docker_account }}/viasoft.administration-frontend:2025.1.0.x{{ docker_image_suffix }}"
+    container_name: "ADM01-2025.1.0"
+    restart: unless-stopped
+    extra_hosts: *default-extra_hosts
+    environment:
+      - ON_PREMISE_MODE=true
+      - USE_SERVERGC=$USE_SERVERGC
+      - GATEWAY_URL={{ frontend.endpoints.gateway_url }}
+      - CDN_URL={{ frontend.endpoints.cdn_url }}
+      - FRONTEND_URL={{ frontend.endpoints.frontend_url }}
+      - CERT_FILE_PATH={{ containers_cert_path }}
+    networks:
+      - servicos
+    volumes:
+      - "{{ certs_directory }}/:{{ certs_directory }}/"
+
+  REL01-2025-1-0:
+    image: "{{ docker_account }}/viasoft.relatorios-frontend:2025.1.0.x{{ docker_image_suffix }}"
+    container_name: "REL01-2025.1.0"
+    restart: unless-stopped
+    extra_hosts: *default-extra_hosts
+    environment:
+      - ON_PREMISE_MODE=true
+      - USE_SERVERGC=$USE_SERVERGC
+      - GATEWAY_URL={{ frontend.endpoints.gateway_url }}
+      - CDN_URL={{ frontend.endpoints.cdn_url }}
+      - FRONTEND_URL={{ frontend.endpoints.frontend_url }}
+      - CERT_FILE_PATH={{ containers_cert_path }}
+    networks:
+      - servicos
+    volumes:
+      - "{{ certs_directory }}/:{{ certs_directory }}/"


### PR DESCRIPTION
## Summary

Restores the 2024.2 and 2025.1 infrastructure-web compose templates removed from the 2025.2 branch. The current 2025.2 template remains unchanged.

## Validation

- Restored files match their historical source blobs exactly.
- `git diff --check` passed.