### PR TITLE
DEVO-6789 - Formaliza runtime de gerenciamento de PRs em QA

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,3 +4,11 @@ warn_list:  # or 'skip_list' to silence them completely
   - ignore-errors
   - meta-no-info
   - role-name
+
+skip_list:
+  # As roles qa_pr_apply/qa_pr_reset compartilham a interface qa_pr_*.
+  - var-naming[no-role-prefix]
+
+extra_vars:
+  compose_dir_path: /tmp/qa-pr-composes
+  versioned_compose_dir_path: /tmp/qa-pr-versioned-composes

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+filter_plugins = ./filter_plugins

--- a/docs/ambiente-qualidade-prs.md
+++ b/docs/ambiente-qualidade-prs.md
@@ -1,0 +1,104 @@
+# Ambiente de qualidade com imagens de PRs
+
+Este fluxo aplica, em um servidor de qualidade já configurado, as imagens publicadas pelos pipelines de PR. Ele é operacional e separado do setup normal: `setup.sh` e `main.yml` não executam estes playbooks.
+
+## Pré-requisitos
+
+- execute no checkout do KorpSetupLinux usado pelo servidor;
+- garanta que o inventário e as variáveis usuais, inclusive `linux_korp`, estejam disponíveis;
+- garanta acesso ao Docker e aos diretórios de compose configurados;
+- valide que o host resolve e confia no certificado de `https://minio-interno-api.korp.com.br`.
+- valide acesso ao registry e à API de `https://harbor.korp.com.br`.
+
+> Atenção: `qa_pr_minio_api` deve apontar para o host da API do MinIO, não para a interface web/console. O playbook faz leituras HTTPS anônimas nesse endpoint e valida o certificado TLS.
+
+## Fluxo recomendado para o QA
+
+Instale o atalho uma vez, a partir do checkout do KorpSetupLinux:
+
+```bash
+./qa-pr install
+qa-pr doctor
+```
+
+No uso diário:
+
+```bash
+# Aplicar ou atualizar uma imagem de PR
+qa-pr apply https://github.com/viasoftkorp/repositorio/pull/123
+
+# Conferir overrides e contêineres ativos
+qa-pr status
+
+# Remover todos os PRs e voltar aos composes base
+qa-pr reset
+```
+
+Em um conflito, o modo padrão pergunta se deve `replace`, `keep` ou `abort`.
+Também é possível decidir previamente com `--replace`, `--keep` ou `--fail`.
+Os logs ficam em `~/.local/state/korp-qa-pr`.
+
+## Aplicar PRs
+
+Informe URLs completas de PRs da organização `viasoftkorp`. Para uma lista CSV:
+
+```bash
+ansible-playbook pr-playbook.yml -e "prs=https://github.com/viasoftkorp/repositorio-a/pull/123,https://github.com/viasoftkorp/repositorio-b/pull/456"
+```
+
+Para uma lista JSON:
+
+```bash
+ansible-playbook pr-playbook.yml -e '{"prs":["https://github.com/viasoftkorp/repositorio-a/pull/123","https://github.com/viasoftkorp/repositorio-b/pull/456"]}'
+```
+
+O playbook consulta os relatórios JSON no bucket `qa-prs`, localiza o serviço pelo nome canônico `korp/<serviço>` nos composes base e cria um override somente para o serviço alvo. Relatórios novos podem declarar `harbor.korp.com.br/qa-prs/<serviço>` e relatórios legados declaram `korp/<serviço>`. Para cada relatório, a role consulta primeiro a tag no Harbor. Um `404` aciona fallback para o DockerHub somente quando o próprio relatório é legado; se um relatório novo declarar Harbor e a tag não existir, a execução falha. Erros de acesso ao Harbor também falham para não mascarar indisponibilidade do registry.
+
+O contêiner aplicado recebe as labels `korp.pr` com o número e `korp.repositorio` com o repositório; juntas, elas formam o ownership `<repositorio>#<N>` exibido no preflight.
+
+### Conflitos
+
+Há conflito quando outro ownership já controla a mesma identidade de serviço: diretório do projeto, arquivo de compose e chave do serviço. PRs de repositórios diferentes com o mesmo número conflitam. Não há conflito ao reaplicar o mesmo `<repositorio>#<N>`, nem quando PRs afetam serviços diferentes, ainda que estejam no mesmo compose.
+
+A política padrão é `ask`:
+
+```bash
+ansible-playbook pr-playbook.yml -e "prs=https://github.com/viasoftkorp/repositorio-a/pull/123"
+```
+
+Para cada conflito, responda `replace`, `keep` ou `abort`. Uma resposta vazia ou inválida equivale a `abort`.
+
+Em automações, defina a política sem interação:
+
+```bash
+ansible-playbook pr-playbook.yml -e "prs=https://github.com/viasoftkorp/repositorio-a/pull/123" -e "pr_conflict_policy=replace"
+```
+
+As políticas são:
+
+- `ask`: pergunta como resolver cada conflito antes de alterar o ambiente;
+- `replace`: remove o serviço do override do PR atual e aplica o serviço do PR solicitado;
+- `keep`: mantém o proprietário atual e ignora somente o alvo conflitante; alvos sem conflito continuam;
+- `fail`: falha se existir qualquer conflito.
+
+Todo o preflight termina antes da primeira gravação ou execução de compose. Portanto, `abort` em `ask` e conflito com `fail` encerram a aplicação inteira sem mutar overrides ou contêineres. Sem conflito, o alvo é aplicado normalmente em qualquer política válida.
+
+### Atualizar após um novo push
+
+O ambiente não acompanha novos commits automaticamente. Depois que o pipeline publicar o relatório e a imagem de um novo push, execute novamente o mesmo comando com o mesmo link. Como o número do PR não mudou, isso é um refresh, não um conflito, e o serviço é reaplicado com a imagem indicada pelo relatório mais recente.
+
+## Resetar o ambiente
+
+```bash
+ansible-playbook pr-reset-playbook.yml
+```
+
+O reset descobre os composes afetados, confirma que cada compose base ainda existe, remove as duas raízes de `pr-overrides` e reaplica integralmente cada compose base afetado. Isso remove todos os overrides de PR; não há reset seletivo por PR. Se não houver overrides, não há compose para reaplicar.
+
+## Riscos aceitos no MVP
+
+- Divergência de versão: o fluxo não garante que a versão declarada pelo relatório do PR corresponda à versão base instalada no ambiente.
+- Não há trava automática contra executar estes playbooks privilegiados em ambiente de cliente final; confirme o host antes da execução.
+- A aplicação pode inicializar serviços e executar seus efeitos de startup.
+- Schema sujo: migrações, dados e outras alterações persistidas fora do compose não são revertidas pela troca de imagem nem pelo reset.
+- Sem refresh automático: cada novo push exige aguardar a publicação e reaplicar manualmente o PR.

--- a/filter_plugins/qa_pr_filters.py
+++ b/filter_plugins/qa_pr_filters.py
@@ -1,0 +1,447 @@
+from copy import deepcopy
+import json
+import re
+from pathlib import PurePosixPath
+from xml.etree import ElementTree
+
+_PR_LINK = re.compile(
+    r"^https://github[.]com/(?P<org>[A-Za-z0-9_.-]+)/"
+    r"(?P<repo>[A-Za-z0-9_.-]+)/pull/(?P<pr>[1-9][0-9]*)/?$"
+)
+_REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+$")
+_VERSION = re.compile(r"^[0-9]+[.][0-9]+[.][0-9]+$")
+_OVERRIDE_PATH = re.compile(
+    r"^.+/pr-overrides/pr(?P<pr>[1-9][0-9]*)/"
+    r"(?P<compose_file>[^/]+-compose[.]yml)$"
+)
+_REQUIRED_CONTAINER_FIELDS = {
+    "kind", "pr", "repositorio", "branch", "servico",
+    "imagem", "tag", "versao", "commit", "build",
+}
+
+
+def normalize_pr_links(value, organization="viasoftkorp"):
+    items = value.split(",") if isinstance(value, str) else list(value or [])
+    result = []
+    for raw in items:
+        url = str(raw).strip()
+        match = _PR_LINK.fullmatch(url)
+        if not match or match.group("org") != organization:
+            raise ValueError(f"Link de PR inválido: {url!r}")
+        repo = match.group("repo")
+        pr = int(match.group("pr"))
+        result.append({"url": url, "repo": repo, "pr": pr, "key": f"{repo}#{pr}"})
+    if not result:
+        raise ValueError("Informe ao menos um link de PR em prs")
+    return result
+
+
+def parse_minio_listing(xml_text, prefix):
+    root = ElementTree.fromstring(xml_text)
+    truncated = next((node.text for node in root.iter() if node.tag.endswith("IsTruncated")), "false")
+    if str(truncated).lower() == "true":
+        raise ValueError(f"Listagem truncada para {prefix}; paginação não implementada")
+    keys = []
+    for node in root.iter():
+        key = node.text
+        if not node.tag.endswith("Key") or not key or not key.startswith(prefix):
+            continue
+        suffix = key[len(prefix):]
+        if suffix and "/" not in suffix and suffix.endswith(".json"):
+            keys.append(key)
+    return sorted(set(keys))
+
+
+def load_report(
+    json_text,
+    expected_repo,
+    expected_pr,
+    expected_key,
+    harbor_registry="harbor.korp.com.br",
+    harbor_project="qa-prs",
+):
+    report = json.loads(json_text)
+    missing = _REQUIRED_CONTAINER_FIELDS - set(report)
+    if missing:
+        raise ValueError(f"Relatório sem campos obrigatórios: {sorted(missing)}")
+    if report["kind"] != "container":
+        raise ValueError(f"kind ainda não suportado nesta fase: {report['kind']}")
+    expected_service = expected_key.rsplit("/", 1)[-1][:-5]
+    registry = str(harbor_registry).strip().strip("/")
+    project = str(harbor_project).strip().strip("/")
+    dockerhub_image = f"korp/{report['servico']}"
+    harbor_image = f"{registry}/{project}/{report['servico']}"
+    if (
+        report["repositorio"] != expected_repo
+        or report["pr"] != expected_pr
+        or report["servico"] != expected_service
+        or report["imagem"] not in {dockerhub_image, harbor_image}
+    ):
+        raise ValueError(f"Relatório inconsistente com {expected_key}")
+    report = dict(report)
+    report["pr_key"] = f"{expected_repo}#{expected_pr}"
+    report["compose_image"] = dockerhub_image
+    report["desired_image"] = f"{report['imagem']}:{report['tag']}"
+    return report
+
+
+def resolve_registry_image(
+    report,
+    harbor_status,
+    harbor_registry="harbor.korp.com.br",
+    harbor_project="qa-prs",
+):
+    if harbor_status not in {200, 404}:
+        raise ValueError(
+            f"Status inesperado ao consultar artefato no Harbor: {harbor_status}"
+        )
+    registry = str(harbor_registry).strip().strip("/")
+    project = str(harbor_project).strip().strip("/")
+    if not registry or not project:
+        raise ValueError("Registry e projeto do Harbor são obrigatórios")
+    harbor_image = f"{registry}/{project}/{report['servico']}"
+    dockerhub_image = f"korp/{report['servico']}"
+    resolved = dict(report)
+    if harbor_status == 200:
+        resolved["desired_image"] = (
+            f"{harbor_image}:{report['tag']}"
+        )
+        resolved["image_registry"] = "harbor"
+    else:
+        if report["imagem"] != dockerhub_image:
+            raise ValueError(
+                "Relatório declara Harbor, mas o artefato não foi encontrado: "
+                f"{harbor_image}:{report['tag']}"
+            )
+        resolved["desired_image"] = f"{dockerhub_image}:{report['tag']}"
+        resolved["image_registry"] = "dockerhub"
+    return resolved
+
+
+def select_report_version(reports):
+    if not reports:
+        raise ValueError("Nenhum relatório disponível para selecionar a versão")
+    versions = set()
+    for report in reports:
+        version = str(report.get("versao", "")).strip()
+        if not _VERSION.fullmatch(version):
+            raise ValueError(f"Versão inválida no relatório: {version!r}")
+        versions.add(version)
+    if len(versions) != 1:
+        raise ValueError(
+            "Os relatórios apontam para versões diferentes: "
+            f"{sorted(versions)}. Execute os PRs separadamente."
+        )
+    return next(iter(versions))
+
+
+def build_targets(reports, compose_files):
+    targets = []
+    for report in reports:
+        matches = []
+        compose_image = report.get("compose_image", report["imagem"])
+        for compose in compose_files:
+            services = (compose.get("content") or {}).get("services") or {}
+            for service_key, config in services.items():
+                image = config.get("image") if isinstance(config, dict) else None
+                if isinstance(image, str) and image.rsplit(":", 1)[0] == compose_image:
+                    matches.append((compose["path"], service_key))
+        if len(matches) != 1:
+            raise ValueError(
+                f"Esperado um compose para {compose_image}; encontrados {len(matches)}"
+            )
+        compose_path, service_key = matches[0]
+        compose = PurePosixPath(compose_path)
+        project_src = str(compose.parent)
+        identity = f"{project_src}|{compose.name}|{service_key}"
+        target_id = f"{report['pr_key']}|{identity}"
+        targets.append({
+            "target_id": target_id,
+            "identity": identity,
+            "pr_key": report["pr_key"],
+            "repo": report["repositorio"],
+            "pr": report["pr"],
+            "service": report["servico"],
+            "service_key": service_key,
+            "desired_image": report["desired_image"],
+            "project_src": project_src,
+            "compose_file": compose.name,
+            "override_path": (
+                f"{project_src}/pr-overrides/pr{report['pr']}/{compose.name}"
+            ),
+        })
+    return targets
+
+
+def index_active_overrides(override_files):
+    owners = {}
+    for override_file in override_files:
+        override_path = str(override_file["path"])
+        project_src = override_file.get("project_src")
+        if not isinstance(project_src, str) or not project_src:
+            raise ValueError(f"Project src inválido em {override_path}")
+        match = _OVERRIDE_PATH.fullmatch(override_path)
+        if not match:
+            raise ValueError(f"Caminho de override inválido: {override_path}")
+        compose_file = match.group("compose_file")
+        path_pr = int(match.group("pr"))
+        expected_path = (
+            f"{project_src}/pr-overrides/pr{path_pr}/{compose_file}"
+        )
+        if override_path != expected_path:
+            raise ValueError(f"Caminho de override inválido: {override_path}")
+        content = override_file.get("content")
+        if not isinstance(content, dict):
+            raise ValueError(f"Override YAML inválido em {override_path}")
+        services = content.get("services")
+        if not isinstance(services, dict) or not services:
+            raise ValueError(f"Override sem services em {override_path}")
+        for service_key, config in services.items():
+            if not isinstance(config, dict):
+                raise ValueError(
+                    f"Serviço inválido em {override_path}: {service_key}"
+                )
+            if not isinstance(config.get("image"), str) or not config["image"]:
+                raise ValueError(
+                    f"Imagem inválida em {override_path}: {service_key}"
+                )
+            if not isinstance(config.get("labels"), dict):
+                raise ValueError(
+                    f"Labels inválidas em {override_path}: {service_key}"
+                )
+            labels = config["labels"]
+            raw_pr = labels.get("korp.pr")
+            try:
+                pr = int(raw_pr)
+            except (TypeError, ValueError) as error:
+                raise ValueError(
+                    f"Label korp.pr inválida em {override_path}: {raw_pr!r}"
+                ) from error
+            if pr <= 0:
+                raise ValueError(
+                    f"Label korp.pr inválida em {override_path}: {raw_pr!r}"
+                )
+            if pr != path_pr:
+                raise ValueError(
+                    f"PR do caminho diverge da label em {override_path}"
+                )
+            raw_repo = labels.get("korp.repositorio")
+            if raw_repo is None:
+                pr_key = f"#{pr}"
+            elif not isinstance(raw_repo, str) or not _REPOSITORY.fullmatch(raw_repo):
+                raise ValueError(
+                    f"Label korp.repositorio inválida em {override_path}: {raw_repo!r}"
+                )
+            else:
+                pr_key = f"{raw_repo}#{pr}"
+            identity = f"{project_src}|{compose_file}|{service_key}"
+            if identity in owners:
+                raise ValueError(f"Mais de um override ativo para {identity}")
+
+            owners[identity] = {
+                "identity": identity,
+                "pr_key": pr_key,
+                "pr": pr,
+                "override_path": override_path,
+                "override_content": deepcopy(content),
+                "project_src": project_src,
+                "compose_file": compose_file,
+                "service_key": service_key,
+            }
+    return owners
+
+
+def detect_conflicts(targets, active_owners, decisions=None):
+    conflicts = []
+    owners = dict(active_owners)
+    interactive = decisions is not None
+    decisions = decisions or {}
+    for target in targets:
+        current = owners.get(target["identity"])
+        if current and current["pr_key"] != target["pr_key"]:
+            conflicts.append({
+                "target_id": target["target_id"],
+                "identity": target["identity"],
+                "current": current,
+                "incoming": target,
+            })
+            if interactive:
+                if target["target_id"] not in decisions:
+                    break
+                decision = decisions[target["target_id"]]
+                if decision == "replace":
+                    owners[target["identity"]] = target
+                elif decision != "keep":
+                    break
+            continue
+        owners[target["identity"]] = target
+    return conflicts
+
+
+def _empty_plan(conflicts):
+    return {
+        "may_mutate": False,
+        "conflicts": conflicts,
+        "apply_targets": [],
+        "skipped_targets": [],
+        "remove_services": [],
+        "writes": [],
+        "deletes": [],
+        "compose_runs": [],
+    }
+
+
+def _build_mutation_plan(
+    accepted, skipped, removals, conflicts, active_owners
+):
+    contents_by_path = {}
+    for owner in active_owners.values():
+        path = owner.get("override_path")
+        if path and "override_content" in owner and path not in contents_by_path:
+            contents_by_path[path] = deepcopy(owner["override_content"])
+
+    modified_paths = {}
+    for removal in removals:
+        path = removal["path"]
+        content = contents_by_path.setdefault(path, {"services": {}})
+        services = content.setdefault("services", {})
+        services.pop(removal["service_key"], None)
+        modified_paths[path] = None
+
+    compose_runs_by_key = {}
+    for target in accepted:
+        path = target["override_path"]
+        content = contents_by_path.setdefault(path, {"services": {}})
+        services = content.setdefault("services", {})
+        services[target["service_key"]] = {
+            "image": target["desired_image"],
+            "labels": {
+                "korp.pr": str(target["pr"]),
+                "korp.repositorio": target["repo"],
+            },
+        }
+        modified_paths[path] = None
+
+        run_key = (
+            target["project_src"],
+            target["compose_file"],
+            target["override_path"],
+        )
+        run = compose_runs_by_key.setdefault(run_key, {
+            "project_src": target["project_src"],
+            "files": [
+                target["compose_file"],
+                str(
+                    PurePosixPath(target["override_path"]).relative_to(
+                        PurePosixPath(target["project_src"])
+                    )
+                ),
+            ],
+            "services": [],
+        })
+        if target["service_key"] not in run["services"]:
+            run["services"].append(target["service_key"])
+
+    writes, deletes = [], []
+    for path in modified_paths:
+        content = contents_by_path[path]
+        if content.get("services"):
+            writes.append({"path": path, "content": content})
+        else:
+            deletes.append(path)
+
+    return {
+        "may_mutate": True,
+        "conflicts": conflicts,
+        "apply_targets": accepted,
+        "skipped_targets": skipped,
+        "remove_services": removals,
+        "writes": writes,
+        "deletes": deletes,
+        "compose_runs": list(compose_runs_by_key.values()),
+    }
+
+
+def resolve_application(targets, active_owners, policy, decisions=None):
+    if policy not in {"ask", "replace", "keep", "fail"}:
+        raise ValueError(f"Política de conflito inválida: {policy}")
+    decisions = decisions or {}
+    if policy == "ask":
+        conflicts = detect_conflicts(targets, active_owners, decisions)
+    elif policy in {"replace", "keep"}:
+        policy_decisions = {
+            target["target_id"]: policy for target in targets
+        }
+        conflicts = detect_conflicts(
+            targets, active_owners, policy_decisions
+        )
+    else:
+        conflicts = detect_conflicts(targets, active_owners)
+    if policy == "fail" and conflicts:
+        return _empty_plan(conflicts)
+    accepted_by_identity, skipped, removals = {}, [], []
+    owners = {
+        identity: {
+            "owner": owner,
+            "persisted": True,
+            "persisted_owner": owner,
+        }
+        for identity, owner in active_owners.items()
+    }
+    for target in targets:
+        state = owners.get(target["identity"])
+        conflict = state and state["owner"]["pr_key"] != target["pr_key"]
+        if not conflict:
+            persisted_owner = state.get("persisted_owner") if state else None
+            accepted_by_identity[target["identity"]] = target
+            owners[target["identity"]] = {
+                "owner": target,
+                "persisted": False,
+                "persisted_owner": persisted_owner,
+            }
+            continue
+        decision = policy if policy != "ask" else decisions.get(
+            target["target_id"], "abort"
+        )
+        if decision == "abort":
+            return _empty_plan(conflicts)
+        if decision == "keep":
+            skipped.append(target)
+            continue
+        if decision != "replace":
+            return _empty_plan(conflicts)
+        persisted_owner = state.get("persisted_owner")
+        accepted_by_identity.pop(target["identity"], None)
+        if persisted_owner:
+            removals.append({
+                "path": persisted_owner["override_path"],
+                "service_key": persisted_owner["service_key"],
+            })
+        accepted_by_identity[target["identity"]] = target
+        owners[target["identity"]] = {
+            "owner": target,
+            "persisted": False,
+            "persisted_owner": None,
+        }
+    return _build_mutation_plan(
+        list(accepted_by_identity.values()),
+        skipped,
+        removals,
+        conflicts,
+        active_owners,
+    )
+
+
+class FilterModule:
+    def filters(self):
+        return {
+            "qa_pr_normalize_links": normalize_pr_links,
+            "qa_pr_parse_minio_listing": parse_minio_listing,
+            "qa_pr_load_report": load_report,
+            "qa_pr_resolve_registry_image": resolve_registry_image,
+            "qa_pr_select_report_version": select_report_version,
+            "qa_pr_build_targets": build_targets,
+            "qa_pr_index_active_overrides": index_active_overrides,
+            "qa_pr_detect_conflicts": detect_conflicts,
+            "qa_pr_resolve_application": resolve_application,
+        }

--- a/pr-playbook.yml
+++ b/pr-playbook.yml
@@ -1,0 +1,10 @@
+---
+- name: Aplicação de PRs no ambiente de qualidade
+  hosts: 127.0.0.1
+  connection: local
+  vars:
+    ansible_become_password: "{{ linux_korp.password }}"
+  become_user: "{{ linux_korp.user }}"
+  become: true
+  roles:
+    - qa_pr_apply

--- a/pr-reset-playbook.yml
+++ b/pr-reset-playbook.yml
@@ -1,0 +1,10 @@
+---
+- name: Reset do ambiente de qualidade
+  hosts: 127.0.0.1
+  connection: local
+  vars:
+    ansible_become_password: "{{ linux_korp.password }}"
+  become_user: "{{ linux_korp.user }}"
+  become: true
+  roles:
+    - qa_pr_reset

--- a/qa-pr
+++ b/qa-pr
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+script_path="$(readlink -f "${BASH_SOURCE[0]}")"
+repo_dir="${QA_PR_REPO_DIR:-$(dirname "$script_path")}"
+inventory="${QA_PR_INVENTORY:-/etc/korp/ansible/inventory.yml}"
+vault_id="${QA_PR_VAULT_ID:-/etc/korp/ansible/.vault_key}"
+compose_root="${QA_PR_COMPOSE_ROOT:-/etc/korp/composes}"
+minio_api="${QA_PR_MINIO_API:-https://minio-interno-api.korp.com.br}"
+harbor_api="${QA_PR_HARBOR_API:-https://harbor.korp.com.br/api/v2.0}"
+log_dir="${QA_PR_LOG_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/korp-qa-pr}"
+sudo_command="${QA_PR_SUDO-sudo}"
+install_path="${QA_PR_INSTALL_PATH:-/usr/local/bin/qa-pr}"
+
+usage() {
+  cat <<'EOF'
+Uso:
+  qa-pr doctor
+  qa-pr apply <URL_DO_PR> [URL_DO_PR...] [--ask|--fail|--keep|--replace]
+  qa-pr status
+  qa-pr reset [--yes]
+  qa-pr install
+
+Exemplos:
+  qa-pr apply https://github.com/viasoftkorp/sdk/pull/330
+  qa-pr apply https://github.com/viasoftkorp/sdk/pull/330 --replace
+  qa-pr status
+  qa-pr reset
+EOF
+}
+
+die() {
+  echo "Erro: $*" >&2
+  exit 1
+}
+
+run_privileged() {
+  if [[ -n "$sudo_command" ]]; then
+    "$sudo_command" "$@"
+  else
+    "$@"
+  fi
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "comando obrigatório não encontrado: $1"
+}
+
+require_runtime() {
+  require_command ansible-playbook
+  [[ -r "$inventory" ]] || die "inventário não encontrado ou sem leitura: $inventory"
+  [[ -r "$vault_id" ]] || die "chave do vault não encontrada ou sem leitura: $vault_id"
+  [[ -f "$repo_dir/pr-playbook.yml" ]] || die "pr-playbook.yml não encontrado em $repo_dir"
+  [[ -f "$repo_dir/pr-reset-playbook.yml" ]] || die "pr-reset-playbook.yml não encontrado em $repo_dir"
+}
+
+run_playbook() {
+  local playbook="$1"
+  shift
+  local timestamp log_file exit_code
+
+  mkdir -p "$log_dir"
+  timestamp="$(date '+%Y%m%d-%H%M%S')"
+  log_file="$log_dir/${playbook%.yml}-$timestamp.log"
+  echo "Log: $log_file"
+
+  set +e
+  ansible-playbook \
+    -i "$inventory" \
+    --vault-id "$vault_id" \
+    "$repo_dir/$playbook" \
+    "$@" 2>&1 | tee "$log_file"
+  exit_code="${PIPESTATUS[0]}"
+  set -e
+  return "$exit_code"
+}
+
+doctor() {
+  local failed=0
+  local command
+
+  echo "Host: $(hostname)"
+  echo "Repositório: $repo_dir"
+  if command -v git >/dev/null 2>&1 && git -C "$repo_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Branch: $(git -C "$repo_dir" branch --show-current) ($(git -C "$repo_dir" rev-parse --short HEAD))"
+  fi
+
+  for command in ansible-playbook ansible-galaxy curl docker; do
+    if command -v "$command" >/dev/null 2>&1; then
+      echo "[ok] $command"
+    else
+      echo "[falha] comando ausente: $command" >&2
+      failed=1
+    fi
+  done
+
+  for command in "$inventory" "$vault_id" "$repo_dir/pr-playbook.yml" "$repo_dir/pr-reset-playbook.yml"; do
+    if [[ -r "$command" ]]; then
+      echo "[ok] $command"
+    else
+      echo "[falha] arquivo ausente ou sem leitura: $command" >&2
+      failed=1
+    fi
+  done
+
+  if command -v ansible-galaxy >/dev/null 2>&1 &&
+    ansible-galaxy collection list community.docker >/dev/null 2>&1; then
+    echo "[ok] collection community.docker"
+  else
+    echo "[falha] collection community.docker indisponível" >&2
+    failed=1
+  fi
+
+  if command -v docker >/dev/null 2>&1 &&
+    run_privileged docker compose version >/dev/null 2>&1 &&
+    run_privileged docker info >/dev/null 2>&1; then
+    echo "[ok] Docker e Compose"
+  else
+    echo "[falha] Docker/Compose indisponível" >&2
+    failed=1
+  fi
+
+  if command -v curl >/dev/null 2>&1 &&
+    curl --fail --silent --show-error \
+      "$minio_api/qa-prs/?list-type=2&max-keys=1" >/dev/null; then
+    echo "[ok] API MinIO"
+  else
+    echo "[falha] API MinIO inacessível: $minio_api" >&2
+    failed=1
+  fi
+
+  if command -v curl >/dev/null 2>&1 &&
+    curl --fail --silent --show-error \
+      "$harbor_api/projects/qa-prs" >/dev/null; then
+    echo "[ok] API Harbor"
+  else
+    echo "[falha] API Harbor inacessível: $harbor_api" >&2
+    failed=1
+  fi
+
+  if ((failed)); then
+    die "ambiente incompleto"
+  fi
+  echo "Ambiente pronto."
+}
+
+apply_prs() {
+  local policy="ask"
+  local argument
+  local -a urls=()
+
+  for argument in "$@"; do
+    case "$argument" in
+      --ask) policy="ask" ;;
+      --fail) policy="fail" ;;
+      --keep) policy="keep" ;;
+      --replace) policy="replace" ;;
+      --*) die "opção desconhecida: $argument" ;;
+      *)
+        if [[ ! "$argument" =~ ^https://github\.com/viasoftkorp/[A-Za-z0-9._-]+/pull/[0-9]+/?$ ]]; then
+          die "URL de PR inválida: $argument"
+        fi
+        urls+=("$argument")
+        ;;
+    esac
+  done
+
+  ((${#urls[@]} > 0)) || die "informe ao menos uma URL de PR"
+  require_runtime
+
+  local joined
+  joined="$(IFS=,; echo "${urls[*]}")"
+  echo "Host alvo: $(hostname)"
+  echo "PRs: $joined"
+  echo "Política de conflito: $policy"
+  run_playbook pr-playbook.yml \
+    -e "prs=$joined" \
+    -e "pr_conflict_policy=$policy"
+}
+
+status_prs() {
+  local override_output container_output
+  require_command docker
+
+  echo "Overrides ativos:"
+  override_output="$(
+    run_privileged find "$compose_root" \
+      -path '*/pr-overrides/*' \
+      -type f \
+      -name '*-compose.yml' \
+      -print 2>/dev/null | sort
+  )"
+  if [[ -n "$override_output" ]]; then
+    echo "$override_output"
+  else
+    echo "(nenhum)"
+  fi
+
+  echo
+  echo "Contêineres de PR (nome|imagem|pr|repositório|status):"
+  container_output="$(
+    run_privileged docker ps -a \
+      --filter label=korp.pr \
+      --format '{{.Names}}|{{.Image}}|{{.Label "korp.pr"}}|{{.Label "korp.repositorio"}}|{{.Status}}'
+  )"
+  if [[ -n "$container_output" ]]; then
+    echo "$container_output"
+  else
+    echo "(nenhum)"
+  fi
+}
+
+reset_prs() {
+  local confirmed=0
+
+  case "${1:-}" in
+    "") ;;
+    --yes) confirmed=1 ;;
+    *) die "uso: qa-pr reset [--yes]" ;;
+  esac
+
+  if ((!confirmed)); then
+    echo "Este comando removerá todos os overrides de PR e reaplicará os composes base."
+    read -r -p "Digite RESET para continuar: " answer
+    if [[ "$answer" != "RESET" ]]; then
+      echo "Reset cancelado."
+      return 2
+    fi
+  fi
+
+  require_runtime
+  echo "Host alvo: $(hostname)"
+  run_playbook pr-reset-playbook.yml
+}
+
+install_cli() {
+  run_privileged ln -sfn "$script_path" "$install_path"
+  echo "qa-pr instalado em $install_path"
+}
+
+main() {
+  local command="${1:-help}"
+  if (($# > 0)); then
+    shift
+  fi
+
+  case "$command" in
+    doctor) (($# == 0)) || die "uso: qa-pr doctor"; doctor ;;
+    apply) apply_prs "$@" ;;
+    status) (($# == 0)) || die "uso: qa-pr status"; status_prs ;;
+    reset) reset_prs "$@" ;;
+    install) (($# == 0)) || die "uso: qa-pr install"; install_cli ;;
+    help|-h|--help) usage ;;
+    *) usage >&2; die "comando desconhecido: $command" ;;
+  esac
+}
+
+main "$@"

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@
 
 Setup destinado para a configuração e manutenção de servidores linux, feito utilizando a ferramenta [Ansible](https://docs.ansible.com/ansible/latest/index.html#).
 
+Para operar imagens de PRs no ambiente de qualidade, consulte o [guia de aplicação e reset](docs/ambiente-qualidade-prs.md).
+
 ---
 
 ## Adição de serviço

--- a/roles/qa_pr_apply/defaults/main.yml
+++ b/roles/qa_pr_apply/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+qa_pr_minio_api: "https://minio-interno-api.korp.com.br"
+qa_pr_minio_bucket: "qa-prs"
+qa_pr_harbor_api: "https://harbor.korp.com.br/api/v2.0"
+qa_pr_harbor_registry: "harbor.korp.com.br"
+qa_pr_harbor_project: "qa-prs"
+qa_pr_github_organization: "viasoftkorp"
+pr_conflict_policy: "ask"
+qa_pr_reports: []
+qa_pr_compose_files: []
+qa_pr_override_files: []
+qa_pr_conflict_decisions: {}

--- a/roles/qa_pr_apply/tasks/apply_compose.yml
+++ b/roles/qa_pr_apply/tasks/apply_compose.yml
@@ -1,0 +1,8 @@
+---
+- name: Aplicar somente os serviços alterados pelo PR
+  community.docker.docker_compose_v2:
+    project_src: "{{ qa_pr_compose_run.project_src }}/"
+    env_files:
+      - "{{ docker_env_file_path }}"
+    files: "{{ qa_pr_compose_run.files }}"
+    services: "{{ qa_pr_compose_run.services }}"

--- a/roles/qa_pr_apply/tasks/load_pr.yml
+++ b/roles/qa_pr_apply/tasks/load_pr.yml
@@ -1,0 +1,36 @@
+---
+- name: Definir prefixo do relatório do PR
+  ansible.builtin.set_fact:
+    qa_pr_minio_prefix: "prs/{{ qa_pr_link.repo }}/{{ qa_pr_link.pr }}/"
+
+- name: Listar relatórios do PR no MinIO
+  ansible.builtin.uri:
+    url: >-
+      {{ qa_pr_minio_api }}/{{ qa_pr_minio_bucket }}/?list-type=2&prefix={{ qa_pr_minio_prefix }}
+    method: GET
+    return_content: true
+    validate_certs: true
+  register: qa_pr_minio_listing
+
+- name: Interpretar listagem do MinIO
+  ansible.builtin.set_fact:
+    qa_pr_minio_keys: >-
+      {{
+        qa_pr_minio_listing.content
+        | qa_pr_parse_minio_listing(qa_pr_minio_prefix)
+      }}
+
+- name: Exigir ao menos um relatório JSON para o PR
+  ansible.builtin.assert:
+    that:
+      - qa_pr_minio_keys | length > 0
+    fail_msg: >-
+      Nenhum relatório JSON encontrado no MinIO para
+      {{ qa_pr_link.key }} em {{ qa_pr_minio_prefix }}.
+
+- name: Carregar objetos de relatório do PR
+  ansible.builtin.include_tasks: load_report.yml
+  loop: "{{ qa_pr_minio_keys }}"
+  loop_control:
+    loop_var: qa_pr_report_key
+    label: "{{ qa_pr_report_key }}"

--- a/roles/qa_pr_apply/tasks/load_report.yml
+++ b/roles/qa_pr_apply/tasks/load_report.yml
@@ -1,0 +1,64 @@
+---
+- name: Ler relatório do MinIO
+  ansible.builtin.uri:
+    url: >-
+      {{ qa_pr_minio_api }}/{{ qa_pr_minio_bucket }}/{{
+        qa_pr_report_key | urlencode
+      }}
+    method: GET
+    return_content: true
+    validate_certs: true
+  register: qa_pr_minio_report
+
+- name: Validar relatório
+  ansible.builtin.set_fact:
+    qa_pr_loaded_report: >-
+      {{
+        qa_pr_minio_report.content
+        | qa_pr_load_report(
+            qa_pr_link.repo,
+            qa_pr_link.pr,
+            qa_pr_report_key,
+            qa_pr_harbor_registry,
+            qa_pr_harbor_project
+          )
+      }}
+
+- name: Consultar imagem do relatório no Harbor
+  ansible.builtin.uri:
+    url: >-
+      {{ qa_pr_harbor_api }}/projects/{{
+        qa_pr_harbor_project | urlencode
+      }}/repositories/{{
+        qa_pr_loaded_report.servico | urlencode
+      }}/artifacts/{{
+        qa_pr_loaded_report.tag | urlencode
+      }}
+    method: GET
+    validate_certs: true
+    status_code:
+      - 200
+      - 404
+  register: qa_pr_harbor_artifact
+
+- name: Resolver origem e acumular relatório
+  ansible.builtin.set_fact:
+    qa_pr_reports: >-
+      {{
+        qa_pr_reports
+        + [
+            qa_pr_loaded_report
+            | qa_pr_resolve_registry_image(
+                qa_pr_harbor_artifact.status,
+                qa_pr_harbor_registry,
+                qa_pr_harbor_project
+              )
+          ]
+      }}
+
+- name: Informar origem da imagem do PR
+  ansible.builtin.debug:
+    msg: >-
+      {{ (qa_pr_reports | last).desired_image }}
+      selecionada via
+      {{ (qa_pr_reports | last).image_registry }}.

--- a/roles/qa_pr_apply/tasks/main.yml
+++ b/roles/qa_pr_apply/tasks/main.yml
@@ -1,0 +1,152 @@
+---
+- name: Normalizar links de PRs
+  ansible.builtin.set_fact:
+    qa_pr_links: >-
+      {{
+        prs
+        | qa_pr_normalize_links(qa_pr_github_organization)
+      }}
+
+- name: Validar política de conflitos
+  ansible.builtin.assert:
+    that:
+      - pr_conflict_policy in ["ask", "replace", "keep", "fail"]
+    fail_msg: >-
+      Política de conflito inválida: {{ pr_conflict_policy }}.
+      Use ask, replace, keep ou fail.
+
+- name: Inicializar preflight de aplicação de PRs
+  ansible.builtin.set_fact:
+    qa_pr_reports: []
+    qa_pr_compose_files: []
+    qa_pr_override_files: []
+    qa_pr_conflict_decisions: {}
+
+- name: Carregar relatórios dos PRs
+  ansible.builtin.include_tasks: load_pr.yml
+  loop: "{{ qa_pr_links }}"
+  loop_control:
+    loop_var: qa_pr_link
+    label: "{{ qa_pr_link.key }}"
+
+- name: Selecionar versão informada pelos relatórios
+  ansible.builtin.set_fact:
+    qa_pr_selected_version: >-
+      {{
+        qa_pr_reports
+        | qa_pr_select_report_version
+      }}
+
+- name: Definir diretórios de compose da versão selecionada
+  ansible.builtin.set_fact:
+    qa_pr_versioned_compose_dir: >-
+      {{
+        compose_dir_path
+        | regex_replace('/+$', '')
+      }}/{{ qa_pr_selected_version }}
+    qa_pr_compose_roots: >-
+      {{
+        [
+          compose_dir_path,
+          (
+            (compose_dir_path | regex_replace('/+$', ''))
+            ~ '/'
+            ~ qa_pr_selected_version
+          )
+        ]
+        | map('regex_replace', '/+$', '')
+        | unique
+        | list
+      }}
+
+- name: Verificar instalação da versão selecionada
+  ansible.builtin.stat:
+    path: "{{ qa_pr_versioned_compose_dir }}"
+  register: qa_pr_versioned_compose_dir_stat
+
+- name: Exigir instalação da versão selecionada
+  ansible.builtin.assert:
+    that:
+      - qa_pr_versioned_compose_dir_stat.stat.exists
+      - qa_pr_versioned_compose_dir_stat.stat.isdir
+    fail_msg: >-
+      A versão {{ qa_pr_selected_version }} informada pelos relatórios
+      não está instalada em {{ qa_pr_versioned_compose_dir }}.
+
+- name: Ler composes base
+  ansible.builtin.include_tasks: read_compose.yml
+  loop: "{{ qa_pr_compose_roots }}"
+  loop_control:
+    loop_var: qa_pr_compose_root
+    label: "{{ qa_pr_compose_root }}"
+
+- name: Ler overrides existentes separadamente
+  ansible.builtin.include_tasks: read_override.yml
+  loop: "{{ qa_pr_compose_roots }}"
+  loop_control:
+    loop_var: qa_pr_project_src
+    label: "{{ qa_pr_project_src }}"
+
+- name: Construir alvos e proprietários ativos
+  ansible.builtin.set_fact:
+    qa_pr_targets: >-
+      {{
+        qa_pr_reports
+        | qa_pr_build_targets(qa_pr_compose_files)
+      }}
+    qa_pr_active_owners: >-
+      {{
+        qa_pr_override_files
+        | qa_pr_index_active_overrides
+      }}
+
+- name: Resolver conflitos interativos em ordem
+  ansible.builtin.include_tasks: prompt_conflict.yml
+  loop: "{{ qa_pr_targets }}"
+  loop_control:
+    loop_var: qa_pr_prompt_target
+    label: "{{ qa_pr_prompt_target.target_id }}"
+  when: pr_conflict_policy == "ask"
+
+- name: Construir plano final de execução
+  ansible.builtin.set_fact:
+    qa_pr_execution_plan: >-
+      {{
+        qa_pr_targets
+        | qa_pr_resolve_application(
+            qa_pr_active_owners,
+            pr_conflict_policy,
+            qa_pr_conflict_decisions
+          )
+      }}
+
+- name: Impedir mutações quando o preflight não autorizar
+  ansible.builtin.assert:
+    that:
+      - qa_pr_execution_plan.may_mutate | bool
+    fail_msg: >-
+      Aplicação de PRs abortada por conflitos:
+      {{ qa_pr_execution_plan.conflicts | to_nice_json }}
+
+- name: Excluir overrides esvaziados pelo plano
+  ansible.builtin.file:
+    path: "{{ qa_pr_override_delete }}"
+    state: absent
+  loop: "{{ qa_pr_execution_plan.deletes }}"
+  loop_control:
+    loop_var: qa_pr_override_delete
+    label: "{{ qa_pr_override_delete }}"
+
+- name: Gravar overrides definidos pelo plano
+  ansible.builtin.include_tasks: write_override.yml
+  loop: "{{ qa_pr_execution_plan.writes }}"
+  loop_control:
+    loop_var: qa_pr_override_write
+    label: "{{ qa_pr_override_write.path }}"
+
+- name: Aplicar serviços definidos pelo plano
+  ansible.builtin.include_tasks: apply_compose.yml
+  loop: "{{ qa_pr_execution_plan.compose_runs }}"
+  loop_control:
+    loop_var: qa_pr_compose_run
+    label: "{{ qa_pr_compose_run.project_src }}"

--- a/roles/qa_pr_apply/tasks/prompt_conflict.yml
+++ b/roles/qa_pr_apply/tasks/prompt_conflict.yml
@@ -1,0 +1,67 @@
+---
+- name: Recalcular conflitos com as decisões já coletadas
+  ansible.builtin.set_fact:
+    qa_pr_prompt_conflicts: >-
+      {{
+        qa_pr_targets
+        | qa_pr_detect_conflicts(
+            qa_pr_active_owners,
+            qa_pr_conflict_decisions
+          )
+      }}
+
+- name: Identificar conflito pendente do alvo atual
+  ansible.builtin.set_fact:
+    qa_pr_pending_conflict: >-
+      {{
+        (qa_pr_prompt_conflicts | last)
+        if (
+          qa_pr_prompt_conflicts | length > 0
+          and (qa_pr_prompt_conflicts | last).target_id
+              == qa_pr_prompt_target.target_id
+          and (qa_pr_prompt_conflicts | last).target_id
+              not in qa_pr_conflict_decisions
+        )
+        else {}
+      }}
+
+- name: Solicitar decisão para o conflito pendente
+  ansible.builtin.pause:
+    prompt: >-
+      Conflito de PR:
+      atual={{ qa_pr_pending_conflict.current.pr_key }},
+      novo={{ qa_pr_pending_conflict.incoming.pr_key }},
+      serviço={{ qa_pr_pending_conflict.incoming.service }},
+      compose={{ qa_pr_pending_conflict.incoming.compose_file }}.
+      Informe replace ou keep; qualquer outra resposta aborta
+  register: qa_pr_conflict_prompt
+  when: >-
+    qa_pr_pending_conflict.target_id | default("")
+    == qa_pr_prompt_target.target_id
+
+- name: Armazenar decisão normalizada do conflito
+  ansible.builtin.set_fact:
+    qa_pr_conflict_decisions: >-
+      {{
+        qa_pr_conflict_decisions
+        | combine(
+            {
+              qa_pr_prompt_target.target_id: (
+                qa_pr_conflict_prompt.user_input
+                | default('abort')
+                | lower
+                | trim
+              )
+              if (
+                qa_pr_conflict_prompt.user_input
+                | default('abort')
+                | lower
+                | trim
+              ) in ['replace', 'keep']
+              else 'abort'
+            }
+          )
+      }}
+  when: >-
+    qa_pr_pending_conflict.target_id | default("")
+    == qa_pr_prompt_target.target_id

--- a/roles/qa_pr_apply/tasks/read_compose.yml
+++ b/roles/qa_pr_apply/tasks/read_compose.yml
@@ -1,0 +1,39 @@
+---
+- name: Encontrar composes base no diretório
+  ansible.builtin.find:
+    paths: "{{ qa_pr_compose_root }}"
+    patterns:
+      - "*-compose.yml"
+    recurse: false
+    file_type: file
+  register: qa_pr_found_composes
+
+- name: Ler composes base encontrados
+  ansible.builtin.slurp:
+    src: "{{ qa_pr_compose_file.path }}"
+  loop: "{{ qa_pr_found_composes.files }}"
+  loop_control:
+    loop_var: qa_pr_compose_file
+    label: "{{ qa_pr_compose_file.path }}"
+  register: qa_pr_slurped_composes
+
+- name: Acumular composes base
+  ansible.builtin.set_fact:
+    qa_pr_compose_files: >-
+      {{
+        qa_pr_compose_files
+        + [
+            {
+              "path": qa_pr_slurped_compose.qa_pr_compose_file.path,
+              "content": (
+                qa_pr_slurped_compose.content
+                | b64decode
+                | from_yaml
+              )
+            }
+          ]
+      }}
+  loop: "{{ qa_pr_slurped_composes.results }}"
+  loop_control:
+    loop_var: qa_pr_slurped_compose
+    label: "{{ qa_pr_slurped_compose.qa_pr_compose_file.path }}"

--- a/roles/qa_pr_apply/tasks/read_override.yml
+++ b/roles/qa_pr_apply/tasks/read_override.yml
@@ -1,0 +1,40 @@
+---
+- name: Encontrar overrides existentes do projeto
+  ansible.builtin.find:
+    paths: "{{ qa_pr_project_src }}/pr-overrides"
+    patterns:
+      - "*-compose.yml"
+    recurse: true
+    file_type: file
+  register: qa_pr_found_overrides
+
+- name: Ler overrides encontrados
+  ansible.builtin.slurp:
+    src: "{{ qa_pr_override_file.path }}"
+  loop: "{{ qa_pr_found_overrides.files }}"
+  loop_control:
+    loop_var: qa_pr_override_file
+    label: "{{ qa_pr_override_file.path }}"
+  register: qa_pr_slurped_overrides
+
+- name: Acumular overrides separadamente
+  ansible.builtin.set_fact:
+    qa_pr_override_files: >-
+      {{
+        qa_pr_override_files
+        + [
+            {
+              "project_src": qa_pr_project_src,
+              "path": qa_pr_slurped_override.qa_pr_override_file.path,
+              "content": (
+                qa_pr_slurped_override.content
+                | b64decode
+                | from_yaml
+              )
+            }
+          ]
+      }}
+  loop: "{{ qa_pr_slurped_overrides.results }}"
+  loop_control:
+    loop_var: qa_pr_slurped_override
+    label: "{{ qa_pr_slurped_override.qa_pr_override_file.path }}"

--- a/roles/qa_pr_apply/tasks/write_override.yml
+++ b/roles/qa_pr_apply/tasks/write_override.yml
@@ -1,0 +1,16 @@
+---
+- name: Criar diretório pai do override
+  ansible.builtin.file:
+    path: "{{ qa_pr_override_write.path | dirname }}"
+    state: directory
+    mode: "0755"
+
+- name: Gravar override do plano
+  ansible.builtin.copy:
+    dest: "{{ qa_pr_override_write.path }}"
+    content: >-
+      {{
+        qa_pr_override_write.content
+        | to_nice_yaml(indent=2, sort_keys=false)
+      }}
+    mode: "0644"

--- a/roles/qa_pr_reset/tasks/main.yml
+++ b/roles/qa_pr_reset/tasks/main.yml
@@ -1,0 +1,101 @@
+---
+- name: Encontrar raízes de overrides de PR instaladas
+  ansible.builtin.find:
+    paths: "{{ compose_dir_path }}"
+    patterns:
+      - pr-overrides
+    file_type: directory
+    recurse: true
+  register: qa_pr_reset_found_override_roots
+
+- name: Inicializar reset dos overrides de PR
+  ansible.builtin.set_fact:
+    qa_pr_reset_runs: []
+    qa_pr_reset_override_files: []
+    qa_pr_reset_compose_roots: >-
+      {{
+        qa_pr_reset_found_override_roots.files
+        | map(attribute='path')
+        | map('regex_replace', '/pr-overrides/?$', '')
+        | unique
+        | list
+      }}
+    qa_pr_reset_override_roots: >-
+      {{
+        qa_pr_reset_found_override_roots.files
+        | map(attribute='path')
+        | map('regex_replace', '/+$', '')
+        | unique
+        | list
+      }}
+
+- name: Ler overrides de PR antes da remoção
+  ansible.builtin.include_tasks: read_override.yml
+  loop: "{{ qa_pr_reset_compose_roots }}"
+  loop_control:
+    loop_var: qa_pr_reset_project_src
+    label: "{{ qa_pr_reset_project_src }}"
+
+- name: Validar todos os overrides antes do reset
+  ansible.builtin.set_fact:
+    qa_pr_reset_active_owners: >-
+      {{ qa_pr_reset_override_files | qa_pr_index_active_overrides }}
+
+- name: Verificar composes base afetados
+  ansible.builtin.stat:
+    path: "{{ qa_pr_reset_run.project_src }}/{{ qa_pr_reset_run.compose_file }}"
+  loop: "{{ qa_pr_reset_runs }}"
+  loop_control:
+    loop_var: qa_pr_reset_run
+    label: >-
+      {{ qa_pr_reset_run.project_src }}/{{ qa_pr_reset_run.compose_file }}
+  register: qa_pr_reset_base_files
+
+- name: Impedir remoção sem compose base
+  ansible.builtin.assert:
+    that:
+      - qa_pr_reset_base_file.stat.exists | bool
+      - qa_pr_reset_base_file.stat.isreg | bool
+    fail_msg: >-
+      Compose base não encontrado para reset:
+      {{ qa_pr_reset_base_file.qa_pr_reset_run.project_src }}/{{
+        qa_pr_reset_base_file.qa_pr_reset_run.compose_file
+      }}
+  loop: "{{ qa_pr_reset_base_files.results }}"
+  loop_control:
+    loop_var: qa_pr_reset_base_file
+    label: >-
+      {{ qa_pr_reset_base_file.qa_pr_reset_run.project_src }}/{{
+        qa_pr_reset_base_file.qa_pr_reset_run.compose_file
+      }}
+
+- name: Validar composes base antes de remover overrides
+  community.docker.docker_compose_v2:
+    project_src: "{{ qa_pr_reset_run.project_src }}/"
+    env_files:
+      - "{{ docker_env_file_path }}"
+    files:
+      - "{{ qa_pr_reset_run.compose_file }}"
+  check_mode: true
+  loop: "{{ qa_pr_reset_runs }}"
+  loop_control:
+    loop_var: qa_pr_reset_run
+    label: >-
+      {{ qa_pr_reset_run.project_src }}/{{ qa_pr_reset_run.compose_file }}
+
+- name: Remover somente as raízes de overrides de PR
+  ansible.builtin.file:
+    path: "{{ qa_pr_reset_override_root }}"
+    state: absent
+  loop: "{{ qa_pr_reset_override_roots }}"
+  loop_control:
+    loop_var: qa_pr_reset_override_root
+    label: "{{ qa_pr_reset_override_root }}"
+
+- name: Reaplicar composes base afetados
+  ansible.builtin.include_tasks: reset_compose.yml
+  loop: "{{ qa_pr_reset_runs }}"
+  loop_control:
+    loop_var: qa_pr_reset_run
+    label: >-
+      {{ qa_pr_reset_run.project_src }}/{{ qa_pr_reset_run.compose_file }}

--- a/roles/qa_pr_reset/tasks/read_override.yml
+++ b/roles/qa_pr_reset/tasks/read_override.yml
@@ -1,0 +1,63 @@
+---
+- name: Encontrar overrides existentes do projeto
+  ansible.builtin.find:
+    paths: "{{ qa_pr_reset_project_src }}/pr-overrides"
+    recurse: true
+    file_type: file
+  register: qa_pr_reset_found_overrides
+
+- name: Ler overrides encontrados antes da remoção
+  ansible.builtin.slurp:
+    src: "{{ qa_pr_reset_override.path }}"
+  loop: "{{ qa_pr_reset_found_overrides.files }}"
+  loop_control:
+    loop_var: qa_pr_reset_override
+    label: "{{ qa_pr_reset_override.path }}"
+  register: qa_pr_reset_slurped_overrides
+
+- name: Acumular overrides para validação conjunta
+  ansible.builtin.set_fact:
+    qa_pr_reset_override_files: >-
+      {{
+        qa_pr_reset_override_files
+        + [
+            {
+              'project_src': qa_pr_reset_project_src,
+              'path': qa_pr_reset_slurped_override.qa_pr_reset_override.path,
+              'content': (
+                qa_pr_reset_slurped_override.content | b64decode | from_yaml
+              )
+            }
+          ]
+      }}
+  loop: "{{ qa_pr_reset_slurped_overrides.results }}"
+  loop_control:
+    loop_var: qa_pr_reset_slurped_override
+    label: "{{ qa_pr_reset_slurped_override.qa_pr_reset_override.path }}"
+
+- name: Acumular composes base afetados sem duplicação
+  ansible.builtin.set_fact:
+    qa_pr_reset_runs: >-
+      {{
+        qa_pr_reset_runs
+        + [
+            {
+              'project_src': qa_pr_reset_project_src,
+              'compose_file': (
+                qa_pr_reset_slurped_override.qa_pr_reset_override.path
+                | basename
+              )
+            }
+          ]
+      }}
+  loop: "{{ qa_pr_reset_slurped_overrides.results }}"
+  loop_control:
+    loop_var: qa_pr_reset_slurped_override
+    label: "{{ qa_pr_reset_slurped_override.qa_pr_reset_override.path }}"
+  when: >-
+    {
+      'project_src': qa_pr_reset_project_src,
+      'compose_file': (
+        qa_pr_reset_slurped_override.qa_pr_reset_override.path | basename
+      )
+    } not in qa_pr_reset_runs

--- a/roles/qa_pr_reset/tasks/reset_compose.yml
+++ b/roles/qa_pr_reset/tasks/reset_compose.yml
@@ -1,0 +1,8 @@
+---
+- name: Reaplicar compose base sem overrides de PR
+  community.docker.docker_compose_v2:
+    project_src: "{{ qa_pr_reset_run.project_src }}/"
+    env_files:
+      - "{{ docker_env_file_path }}"
+    files:
+      - "{{ qa_pr_reset_run.compose_file }}"

--- a/tests/fixtures/qa_prs/base-compose.yml
+++ b/tests/fixtures/qa_prs/base-compose.yml
@@ -1,0 +1,3 @@
+services:
+  korp-compras-core:
+    image: korp/korp.compras.core:2025.1.0.x

--- a/tests/fixtures/qa_prs/existing-override.yml
+++ b/tests/fixtures/qa_prs/existing-override.yml
@@ -1,0 +1,9 @@
+services:
+  wms-core:
+    image: korp/wms-core:pr579
+    labels:
+      korp.pr: "579"
+  wms-gateway:
+    image: korp/wms-gateway:pr579
+    labels:
+      korp.pr: "579"

--- a/tests/fixtures/qa_prs/korp.compras.core.json
+++ b/tests/fixtures/qa_prs/korp.compras.core.json
@@ -1,0 +1,12 @@
+{
+  "kind": "container",
+  "pr": 123,
+  "repositorio": "compras",
+  "branch": "DEVO-6789-ajuste",
+  "servico": "korp.compras.core",
+  "imagem": "korp/korp.compras.core",
+  "tag": "2025.1.0.42-pr123",
+  "versao": "2025.1.0",
+  "commit": "abc1234",
+  "build": 42
+}

--- a/tests/fixtures/qa_prs/listing.xml
+++ b/tests/fixtures/qa_prs/listing.xml
@@ -1,0 +1,5 @@
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <IsTruncated>false</IsTruncated>
+  <Contents><Key>prs/compras/123/korp.compras.core.json</Key></Contents>
+  <Contents><Key>prs/compras/999/outro.json</Key></Contents>
+</ListBucketResult>

--- a/tests/unit/test_qa_pr_cli.py
+++ b/tests/unit/test_qa_pr_cli.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+import os
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CLI = ROOT / "qa-pr"
+
+
+class QaPrCliTests(unittest.TestCase):
+    def setUp(self):
+        self.assertTrue(CLI.exists(), "qa-pr deve existir na raiz")
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.temp = Path(self.temp_dir.name)
+        self.bin_dir = self.temp / "bin"
+        self.bin_dir.mkdir()
+        self.inventory = self.temp / "inventory.yml"
+        self.inventory.write_text("all: {}\n")
+        self.vault = self.temp / ".vault_key"
+        self.vault.write_text("test\n")
+        self.compose_root = self.temp / "composes"
+        self.compose_root.mkdir()
+        self.calls = self.temp / "calls"
+        self._fake_command(
+            "ansible-playbook",
+            '#!/usr/bin/env bash\nprintf "%s\\n" "$@" >> "$QA_PR_FAKE_CALLS"\n',
+        )
+        self._fake_command("ansible-galaxy", "#!/usr/bin/env bash\nexit 0\n")
+        self._fake_command("curl", "#!/usr/bin/env bash\nexit 0\n")
+        self._fake_command(
+            "docker",
+            (
+                "#!/usr/bin/env bash\n"
+                'if [[ "${1:-}" == "ps" ]]; then\n'
+                "  echo 'workflow|korp/workflow:pr330|330|sdk|running'\n"
+                "fi\n"
+            ),
+        )
+        self.environment = os.environ.copy()
+        self.environment.update({
+            "PATH": f"{self.bin_dir}:{self.environment['PATH']}",
+            "QA_PR_FAKE_CALLS": str(self.calls),
+            "QA_PR_INVENTORY": str(self.inventory),
+            "QA_PR_VAULT_ID": str(self.vault),
+            "QA_PR_COMPOSE_ROOT": str(self.compose_root),
+            "QA_PR_LOG_DIR": str(self.temp / "logs"),
+            "QA_PR_SUDO": "",
+        })
+
+    def _fake_command(self, name, content):
+        path = self.bin_dir / name
+        path.write_text(content)
+        path.chmod(0o755)
+
+    def _run(self, *arguments, input_text=None):
+        return subprocess.run(
+            [str(CLI), *arguments],
+            cwd=ROOT,
+            env=self.environment,
+            input=input_text,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_apply_translates_url_and_policy_to_playbook(self):
+        result = self._run(
+            "apply",
+            "https://github.com/viasoftkorp/sdk/pull/330",
+            "--replace",
+        )
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        call = self.calls.read_text()
+        self.assertIn(str(ROOT / "pr-playbook.yml"), call)
+        self.assertIn("prs=https://github.com/viasoftkorp/sdk/pull/330", call)
+        self.assertIn("pr_conflict_policy=replace", call)
+
+    def test_apply_rejects_non_korp_pull_request(self):
+        result = self._run(
+            "apply",
+            "https://github.com/outra-org/sdk/pull/330",
+        )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("URL de PR inválida", result.stderr)
+        self.assertFalse(self.calls.exists())
+
+    def test_reset_requires_confirmation_and_supports_yes(self):
+        cancelled = self._run("reset", input_text="nao\n")
+        self.assertEqual(2, cancelled.returncode)
+        self.assertFalse(self.calls.exists())
+
+        accepted = self._run("reset", "--yes")
+        self.assertEqual(0, accepted.returncode, accepted.stdout + accepted.stderr)
+        self.assertIn(
+            str(ROOT / "pr-reset-playbook.yml"),
+            self.calls.read_text(),
+        )
+
+    def test_status_lists_override_and_labeled_container(self):
+        override = (
+            self.compose_root
+            / "pr-overrides/pr330/workflow-compose.yml"
+        )
+        override.parent.mkdir(parents=True)
+        override.write_text("services: {}\n")
+
+        result = self._run("status")
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn(str(override), result.stdout)
+        self.assertIn("workflow|korp/workflow:pr330|330|sdk|running", result.stdout)
+
+    def test_doctor_checks_runtime_without_running_playbooks(self):
+        result = self._run("doctor")
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn("Ambiente pronto", result.stdout)
+        self.assertIn("[ok] API Harbor", result.stdout)
+        self.assertFalse(self.calls.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_qa_pr_filters.py
+++ b/tests/unit/test_qa_pr_filters.py
@@ -1,0 +1,880 @@
+from copy import deepcopy
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import json
+import os
+import shutil
+import subprocess
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_PATH = ROOT / "filter_plugins/qa_pr_filters.py"
+spec = spec_from_file_location("qa_pr_filters", PLUGIN_PATH)
+filters = module_from_spec(spec)
+spec.loader.exec_module(filters)
+
+
+def target(
+    pr_key,
+    pr,
+    service_key,
+    project_src="/etc/korp/composes",
+    compose_file="logistica-compose.yml",
+):
+    identity = f"{project_src}|{compose_file}|{service_key}"
+    return {
+        "target_id": f"{pr_key}|{identity}",
+        "identity": identity,
+        "pr_key": pr_key,
+        "repo": pr_key.rsplit("#", 1)[0],
+        "pr": pr,
+        "service": service_key,
+        "service_key": service_key,
+        "desired_image": f"korp/{service_key}:pr{pr}",
+        "project_src": project_src,
+        "compose_file": compose_file,
+        "override_path": f"{project_src}/pr-overrides/pr{pr}/{compose_file}",
+    }
+
+
+class PluginDiscoveryTests(unittest.TestCase):
+    def test_root_config_loads_shared_filter_for_ad_hoc_ansible(self):
+        ansible_binary = shutil.which("ansible")
+        self.assertIsNotNone(
+            ansible_binary,
+            "Ative o ambiente Ansible antes de executar os testes",
+        )
+        environment = os.environ.copy()
+        environment.pop("ANSIBLE_CONFIG", None)
+        environment.pop("ANSIBLE_FILTER_PLUGINS", None)
+        environment["ANSIBLE_COLLECTIONS_PATH"] = (
+            "/tmp/devo-6789-collections"
+        )
+        result = subprocess.run(
+            [
+                ansible_binary,
+                "localhost",
+                "-i",
+                "localhost,",
+                "-c",
+                "local",
+                "-m",
+                "ansible.builtin.debug",
+                "-a",
+                "msg={{ [] | qa_pr_index_active_overrides }}",
+            ],
+            cwd=ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            result.stdout + result.stderr,
+        )
+        self.assertIn('"msg": {}', result.stdout)
+
+
+class NormalizePrLinksTests(unittest.TestCase):
+    def test_accepts_csv_and_preserves_order(self):
+        value = (
+            "https://github.com/viasoftkorp/compras/pull/123,"
+            " https://github.com/viasoftkorp/vendas/pull/456/"
+        )
+        self.assertEqual(
+            filters.normalize_pr_links(value),
+            [
+                {
+                    "url": "https://github.com/viasoftkorp/compras/pull/123",
+                    "repo": "compras",
+                    "pr": 123,
+                    "key": "compras#123",
+                },
+                {
+                    "url": "https://github.com/viasoftkorp/vendas/pull/456/",
+                    "repo": "vendas",
+                    "pr": 456,
+                    "key": "vendas#456",
+                },
+            ],
+        )
+
+    def test_rejects_unqualified_or_foreign_links(self):
+        for value in ("123", "https://github.com/outra/compras/pull/123"):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                filters.normalize_pr_links(value)
+
+    def test_rejects_empty_input(self):
+        with self.assertRaises(ValueError):
+            filters.normalize_pr_links("")
+
+
+class MinioParsingTests(unittest.TestCase):
+    def test_extracts_only_json_keys_under_expected_prefix(self):
+        xml_text = (ROOT / "tests/fixtures/qa_prs/listing.xml").read_text()
+        self.assertEqual(
+            filters.parse_minio_listing(xml_text, "prs/compras/123/"),
+            ["prs/compras/123/korp.compras.core.json"],
+        )
+
+    def test_rejects_truncated_listing(self):
+        xml_text = """
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+          <IsTruncated>true</IsTruncated>
+        </ListBucketResult>
+        """
+        with self.assertRaises(ValueError):
+            filters.parse_minio_listing(xml_text, "prs/compras/123/")
+
+    def test_listing_rejects_nested_json_objects(self):
+        xml_text = """
+        <ListBucketResult>
+          <IsTruncated>false</IsTruncated>
+          <Contents><Key>prs/repo-a/123/service.json</Key></Contents>
+          <Contents><Key>prs/repo-a/123/nested/other.json</Key></Contents>
+        </ListBucketResult>
+        """
+        self.assertEqual(
+            filters.parse_minio_listing(xml_text, "prs/repo-a/123/"),
+            ["prs/repo-a/123/service.json"],
+        )
+
+class ReportParsingTests(unittest.TestCase):
+    def test_validates_container_report_against_object_key(self):
+        raw = (ROOT / "tests/fixtures/qa_prs/korp.compras.core.json").read_text()
+        report = filters.load_report(
+            raw,
+            "compras",
+            123,
+            "prs/compras/123/korp.compras.core.json",
+        )
+        self.assertEqual(report["desired_image"], "korp/korp.compras.core:2025.1.0.42-pr123")
+        self.assertEqual(report["compose_image"], "korp/korp.compras.core")
+
+    def test_accepts_report_that_already_points_to_harbor(self):
+        payload = json.loads(
+            (ROOT / "tests/fixtures/qa_prs/korp.compras.core.json").read_text()
+        )
+        payload["imagem"] = "harbor.korp.com.br/qa-prs/korp.compras.core"
+
+        report = filters.load_report(
+            json.dumps(payload),
+            "compras",
+            123,
+            "prs/compras/123/korp.compras.core.json",
+        )
+
+        self.assertEqual(report["compose_image"], "korp/korp.compras.core")
+        self.assertEqual(
+            report["desired_image"],
+            "harbor.korp.com.br/qa-prs/korp.compras.core:"
+            "2025.1.0.42-pr123",
+        )
+
+    def test_rejects_kind_not_implemented_in_phase_one(self):
+        raw = json.dumps({
+            "kind": "delphi",
+            "pr": 123,
+            "repositorio": "compras",
+            "branch": "DEVO-6789-delphi",
+            "servico": "KorpCadastrosService",
+            "imagem": "korp/KorpCadastrosService",
+            "tag": "2025.1.0.42-pr123",
+            "versao": "2025.1.0",
+            "commit": "abc1234",
+            "build": 42,
+        })
+        with self.assertRaises(ValueError):
+            filters.load_report(
+                raw,
+                "compras",
+                123,
+                "prs/compras/123/KorpCadastrosService.json",
+            )
+
+
+class RegistryResolutionTests(unittest.TestCase):
+    def setUp(self):
+        raw = (ROOT / "tests/fixtures/qa_prs/korp.compras.core.json").read_text()
+        self.report = filters.load_report(
+            raw,
+            "compras",
+            123,
+            "prs/compras/123/korp.compras.core.json",
+        )
+
+    def test_prefers_harbor_when_artifact_exists(self):
+        harbor_report = dict(self.report)
+        harbor_report["imagem"] = "harbor.korp.com.br/qa-prs/korp.compras.core"
+        resolved = filters.resolve_registry_image(
+            harbor_report,
+            200,
+            "harbor.korp.com.br",
+            "qa-prs",
+        )
+
+        self.assertEqual(
+            resolved["desired_image"],
+            "harbor.korp.com.br/qa-prs/korp.compras.core:"
+            "2025.1.0.42-pr123",
+        )
+        self.assertEqual(resolved["image_registry"], "harbor")
+
+    def test_falls_back_to_report_image_only_when_harbor_returns_404(self):
+        resolved = filters.resolve_registry_image(
+            self.report,
+            404,
+            "harbor.korp.com.br",
+            "qa-prs",
+        )
+
+        self.assertEqual(
+            resolved["desired_image"],
+            "korp/korp.compras.core:2025.1.0.42-pr123",
+        )
+        self.assertEqual(resolved["image_registry"], "dockerhub")
+
+        with self.assertRaises(ValueError):
+            filters.resolve_registry_image(
+                self.report,
+                503,
+                "harbor.korp.com.br",
+                "qa-prs",
+            )
+
+    def test_does_not_fallback_when_new_report_points_to_missing_harbor_tag(self):
+        harbor_report = dict(self.report)
+        harbor_report["imagem"] = "harbor.korp.com.br/qa-prs/korp.compras.core"
+
+        with self.assertRaisesRegex(ValueError, "declara Harbor"):
+            filters.resolve_registry_image(
+                harbor_report,
+                404,
+                "harbor.korp.com.br",
+                "qa-prs",
+            )
+
+
+class ReportVersionTests(unittest.TestCase):
+    def test_selects_the_single_report_version(self):
+        reports = [
+            {"versao": "2025.1.0"},
+            {"versao": "2025.1.0"},
+        ]
+
+        self.assertEqual(
+            "2025.1.0",
+            filters.select_report_version(reports),
+        )
+
+    def test_rejects_reports_from_different_versions(self):
+        reports = [
+            {"versao": "2024.2.0"},
+            {"versao": "2025.1.0"},
+        ]
+
+        with self.assertRaisesRegex(ValueError, "versões diferentes"):
+            filters.select_report_version(reports)
+
+    def test_rejects_unsafe_or_missing_version(self):
+        for reports in ([], [{"versao": "../2025.1.0"}], [{}]):
+            with self.subTest(reports=reports):
+                with self.assertRaises(ValueError):
+                    filters.select_report_version(reports)
+
+
+class BuildTargetsTests(unittest.TestCase):
+    def test_finds_service_by_image_and_keeps_yaml_service_key(self):
+        reports = [{
+            "pr_key": "compras#123",
+            "repositorio": "compras",
+            "pr": 123,
+            "servico": "korp.compras.core",
+            "imagem": "harbor.korp.com.br/qa-prs/korp.compras.core",
+            "compose_image": "korp/korp.compras.core",
+            "tag": "2025.1.0.42-pr123",
+            "desired_image": "harbor.korp.com.br/qa-prs/korp.compras.core:2025.1.0.42-pr123",
+        }]
+        compose_files = [{
+            "path": "/etc/korp/composes/compras-compose.yml",
+            "content": {
+                "services": {
+                    "korp-compras-core": {
+                        "image": "korp/korp.compras.core:2025.1.0.x"
+                    }
+                }
+            },
+        }]
+        targets = filters.build_targets(reports, compose_files)
+        self.assertEqual(targets[0]["service_key"], "korp-compras-core")
+        self.assertEqual(targets[0]["project_src"], "/etc/korp/composes")
+        self.assertEqual(
+            targets[0]["override_path"],
+            "/etc/korp/composes/pr-overrides/pr123/compras-compose.yml",
+        )
+
+    def test_rejects_service_not_found_or_duplicated(self):
+        report = {
+            "pr_key": "compras#123",
+            "repositorio": "compras",
+            "pr": 123,
+            "servico": "korp.compras.core",
+            "imagem": "korp/korp.compras.core",
+            "tag": "2025.1.0.42-pr123",
+            "desired_image": "korp/korp.compras.core:2025.1.0.42-pr123",
+        }
+        with self.assertRaises(ValueError):
+            filters.build_targets([report], [])
+        duplicate = [
+            {"path": f"/tmp/{name}-compose.yml",
+             "content": {"services": {"core": {"image": "korp/korp.compras.core:base"}}}}
+            for name in ("a", "b")
+        ]
+        with self.assertRaises(ValueError):
+            filters.build_targets([report], duplicate)
+
+
+class ConflictPlanningTests(unittest.TestCase):
+    def setUp(self):
+        self.current = target(
+            pr_key="logistica#579", pr=579, service_key="wms-core"
+        )
+        self.incoming = target(
+            pr_key="logistica#580", pr=580, service_key="wms-core"
+        )
+        self.other_service = target(
+            pr_key="logistica#580", pr=580, service_key="wms-gateway"
+        )
+        self.active = {
+            self.current["identity"]: {
+                "pr_key": "logistica#579",
+                "pr": 579,
+                "override_path": self.current["override_path"],
+                "service_key": "wms-core",
+            }
+        }
+
+    def test_different_service_in_same_compose_is_not_a_conflict(self):
+        plan = filters.resolve_application(
+            [self.other_service], self.active, policy="fail"
+        )
+        self.assertEqual(plan["conflicts"], [])
+        self.assertEqual(plan["apply_targets"], [self.other_service])
+
+    def test_reapplying_same_pr_is_not_a_conflict(self):
+        plan = filters.resolve_application(
+            [self.current], self.active, policy="fail"
+        )
+        self.assertEqual(plan["conflicts"], [])
+
+    def test_same_number_from_different_repositories_conflicts(self):
+        current = target("repo-a#123", 123, "wms-core")
+        incoming = target("repo-b#123", 123, "wms-core")
+        conflicts = filters.detect_conflicts([current, incoming], {})
+        self.assertEqual(
+            [conflict["target_id"] for conflict in conflicts],
+            [incoming["target_id"]],
+        )
+
+    def test_repo_qualified_refresh_does_not_conflict(self):
+        incoming = target("repo-a#123", 123, "wms-core")
+        owner = {**incoming, "pr_key": "repo-a#123"}
+        self.assertEqual(
+            filters.detect_conflicts(
+                [incoming], {incoming["identity"]: owner}
+            ),
+            [],
+        )
+
+    def test_legacy_numeric_owner_conflicts_conservatively(self):
+        incoming = target("repo-a#123", 123, "wms-core")
+        owner = {**incoming, "pr_key": "#123"}
+        self.assertEqual(
+            len(filters.detect_conflicts(
+                [incoming], {incoming["identity"]: owner}
+            )),
+            1,
+        )
+
+    def test_fail_and_abort_produce_no_mutations(self):
+        for policy, decisions in (
+            ("fail", {}),
+            ("ask", {self.incoming["target_id"]: "abort"}),
+        ):
+            plan = filters.resolve_application(
+                [self.incoming], self.active, policy=policy, decisions=decisions
+            )
+            self.assertFalse(plan["may_mutate"])
+            self.assertEqual(plan["writes"], [])
+            self.assertEqual(plan["deletes"], [])
+
+    def test_keep_skips_only_conflicting_target(self):
+        plan = filters.resolve_application(
+            [self.incoming, self.other_service], self.active, policy="keep"
+        )
+        self.assertEqual(plan["skipped_targets"], [self.incoming])
+        self.assertEqual(plan["apply_targets"], [self.other_service])
+
+    def test_replace_removes_old_owner_and_applies_new_target(self):
+        plan = filters.resolve_application(
+            [self.incoming], self.active, policy="replace"
+        )
+        self.assertEqual(
+            plan["remove_services"],
+            [{
+                "path": self.current["override_path"],
+                "service_key": "wms-core",
+            }],
+        )
+        self.assertEqual(plan["apply_targets"], [self.incoming])
+
+    def test_two_argument_detection_uses_keep_at_collisions(self):
+        conflicts = filters.detect_conflicts(
+            [self.incoming, self.current], self.active
+        )
+        self.assertEqual(
+            [conflict["target_id"] for conflict in conflicts],
+            [self.incoming["target_id"]],
+        )
+
+    def test_explicit_empty_decisions_stops_at_first_unresolved_conflict(self):
+        later = target("logistica#581", 581, "wms-core")
+        conflicts = filters.detect_conflicts(
+            [self.incoming, later], self.active, {}
+        )
+        self.assertEqual(
+            [conflict["target_id"] for conflict in conflicts],
+            [self.incoming["target_id"]],
+        )
+
+    def test_explicit_keep_preserves_owner_for_following_refresh(self):
+        conflicts = filters.detect_conflicts(
+            [self.incoming, self.current],
+            self.active,
+            {self.incoming["target_id"]: "keep"},
+        )
+        self.assertEqual(
+            [conflict["target_id"] for conflict in conflicts],
+            [self.incoming["target_id"]],
+        )
+
+    def test_explicit_replace_reveals_next_real_conflict(self):
+        conflicts = filters.detect_conflicts(
+            [self.incoming, self.current],
+            self.active,
+            {self.incoming["target_id"]: "replace"},
+        )
+        self.assertEqual(
+            [conflict["target_id"] for conflict in conflicts],
+            [self.incoming["target_id"], self.current["target_id"]],
+        )
+        self.assertEqual(conflicts[1]["current"], self.incoming)
+
+    def test_plan_conflicts_follow_ask_replay(self):
+        keep_plan = filters.resolve_application(
+            [self.incoming, self.current],
+            self.active,
+            policy="ask",
+            decisions={self.incoming["target_id"]: "keep"},
+        )
+        replace_plan = filters.resolve_application(
+            [self.incoming, self.current],
+            self.active,
+            policy="ask",
+            decisions={
+                self.incoming["target_id"]: "replace",
+                self.current["target_id"]: "keep",
+            },
+        )
+        self.assertEqual(
+            [conflict["target_id"] for conflict in keep_plan["conflicts"]],
+            [self.incoming["target_id"]],
+        )
+        self.assertEqual(
+            [conflict["target_id"] for conflict in replace_plan["conflicts"]],
+            [self.incoming["target_id"], self.current["target_id"]],
+        )
+
+
+class MutationShapeTests(unittest.TestCase):
+    def setUp(self):
+        self.old_path = (
+            "/etc/korp/composes/pr-overrides/pr579/logistica-compose.yml"
+        )
+        self.current_content = {
+            "services": {
+                "wms-core": {
+                    "image": "korp/wms-core:pr579",
+                    "labels": {"korp.pr": "579"},
+                },
+                "wms-gateway": {
+                    "image": "korp/wms-gateway:pr579",
+                    "labels": {"korp.pr": "579"},
+                },
+            }
+        }
+
+    def active_owners(self, content=None):
+        override_file = {
+            "project_src": "/etc/korp/composes",
+            "path": self.old_path,
+            "content": content or self.current_content,
+        }
+        return filters.index_active_overrides([override_file]), override_file
+
+    def test_indexes_each_active_service_without_aliasing_input(self):
+        active, override_file = self.active_owners()
+        core_identity = "/etc/korp/composes|logistica-compose.yml|wms-core"
+        self.assertEqual(active[core_identity]["pr_key"], "#579")
+        self.assertEqual(active[core_identity]["pr"], 579)
+        self.assertEqual(active[core_identity]["override_path"], self.old_path)
+        self.assertEqual(active[core_identity]["service_key"], "wms-core")
+        self.assertIsNot(
+            active[core_identity]["override_content"], override_file["content"]
+        )
+
+    def test_indexes_repo_qualified_owner(self):
+        content = deepcopy(self.current_content)
+        content["services"]["wms-core"]["labels"]["korp.repositorio"] = (
+            "logistica"
+        )
+        active, _ = self.active_owners(content)
+        identity = "/etc/korp/composes|logistica-compose.yml|wms-core"
+        self.assertEqual(active[identity]["pr_key"], "logistica#579")
+
+    def test_indexes_valid_legacy_owner_without_repository_label(self):
+        active = filters.index_active_overrides([{
+            "project_src": "/srv",
+            "path": "/srv/pr-overrides/pr123/app-compose.yml",
+            "content": {
+                "services": {
+                    "api": {
+                        "image": "korp/api:pr123",
+                        "labels": {"korp.pr": "123"},
+                    }
+                }
+            },
+        }])
+        identity = "/srv|app-compose.yml|api"
+        self.assertEqual(active[identity]["pr_key"], "#123")
+
+    def test_rejects_service_without_pr_label(self):
+        content = deepcopy(self.current_content)
+        del content["services"]["wms-core"]["labels"]["korp.pr"]
+        with self.assertRaisesRegex(ValueError, "Label korp.pr inválida"):
+            self.active_owners(content)
+
+    def test_rejects_repeated_override_root_for_expected_project(self):
+        override_file = {
+            "project_src": "/srv",
+            "path": (
+                "/srv/pr-overrides/pr1/pr-overrides/"
+                "pr123/app-compose.yml"
+            ),
+            "content": {
+                "services": {
+                    "api": {
+                        "image": "korp/api:pr123",
+                        "labels": {"korp.pr": "123"},
+                    }
+                }
+            },
+        }
+        with self.assertRaisesRegex(ValueError, "Caminho de override inválido"):
+            filters.index_active_overrides([override_file])
+
+    def test_rejects_missing_or_mismatched_project_src(self):
+        content = {
+            "services": {
+                "api": {
+                    "image": "korp/api:pr123",
+                    "labels": {"korp.pr": "123"},
+                }
+            }
+        }
+        invalid_overrides = [
+            {
+                "path": "/srv/pr-overrides/pr123/app-compose.yml",
+                "content": content,
+            },
+            {
+                "project_src": "/srv/other",
+                "path": "/srv/pr-overrides/pr123/app-compose.yml",
+                "content": content,
+            },
+        ]
+        for override_file in invalid_overrides:
+            with self.subTest(override_file=override_file):
+                with self.assertRaises(ValueError):
+                    filters.index_active_overrides([override_file])
+
+    def test_rejects_invalid_override_schema(self):
+        invalid_overrides = [
+            {
+                "project_src": "/srv",
+                "path": "/srv/pr-overrides/pr123/app-compose.yml",
+                "content": [],
+            },
+            {
+                "project_src": "/srv",
+                "path": "/srv/pr-overrides/pr123/app-compose.yml",
+                "content": {"services": {}},
+            },
+            {
+                "project_src": "/srv",
+                "path": "/srv/pr-overrides/pr123/app-compose.yml",
+                "content": {
+                    "services": {
+                        "api": {"labels": {"korp.pr": "123"}}
+                    }
+                },
+            },
+            {
+                "project_src": "/srv",
+                "path": (
+                    "/srv/pr-overrides/pr123/nested/app-compose.yml"
+                ),
+                "content": {
+                    "services": {
+                        "api": {
+                            "image": "korp/api:pr123",
+                            "labels": {"korp.pr": "123"},
+                        }
+                    }
+                },
+            },
+        ]
+        for override_file in invalid_overrides:
+            with self.subTest(override_file=override_file):
+                with self.assertRaises(ValueError):
+                    filters.index_active_overrides([override_file])
+
+    def test_rejects_invalid_repository_label(self):
+        content = deepcopy(self.current_content)
+        content["services"]["wms-core"]["labels"]["korp.repositorio"] = (
+            "repo/invalido"
+        )
+        with self.assertRaisesRegex(
+            ValueError, "Label korp.repositorio inválida"
+        ):
+            self.active_owners(content)
+
+    def test_rejects_duplicate_persisted_owner_identity(self):
+        override_files = [
+            {
+                "project_src": "/etc/korp/composes",
+                "path": (
+                    f"/etc/korp/composes/pr-overrides/pr{pr}/"
+                    "logistica-compose.yml"
+                ),
+                "content": {
+                    "services": {
+                        "wms-core": {
+                            "image": f"korp/wms-core:pr{pr}",
+                            "labels": {"korp.pr": str(pr)},
+                        }
+                    }
+                },
+            }
+            for pr in (579, 580)
+        ]
+        with self.assertRaisesRegex(ValueError, "Mais de um override ativo"):
+            filters.index_active_overrides(override_files)
+
+    def test_rejects_noncanonical_override_paths(self):
+        paths = (
+            "/etc/korp/composes/pr-overrides/logistica-compose.yml",
+            "/etc/korp/composes/pr-overrides/pr0/logistica-compose.yml",
+            "/etc/korp/composes/pr-overrides/pr579/nested/logistica-compose.yml",
+            "/etc/korp/composes/pr-overrides/pr579/logistica.yml",
+        )
+        for path in paths:
+            with self.subTest(path=path), self.assertRaisesRegex(
+                ValueError, "Caminho de override inválido"
+            ):
+                filters.index_active_overrides([{
+                    "project_src": "/etc/korp/composes",
+                    "path": path,
+                    "content": self.current_content,
+                }])
+
+    def test_rejects_nonpositive_pr_label(self):
+        override_file = {
+            "project_src": "/etc/korp/composes",
+            "path": "/etc/korp/composes/pr-overrides/pr1/logistica-compose.yml",
+            "content": {
+                "services": {
+                    "wms-core": {
+                        "image": "korp/wms-core:pr1",
+                        "labels": {"korp.pr": "0"},
+                    }
+                }
+            },
+        }
+        with self.assertRaisesRegex(ValueError, "Label korp.pr inválida"):
+            filters.index_active_overrides([override_file])
+
+    def test_rejects_override_path_pr_different_from_label(self):
+        override_file = {
+            "project_src": "/etc/korp/composes",
+            "path": "/etc/korp/composes/pr-overrides/pr580/logistica-compose.yml",
+            "content": {
+                "services": {
+                    "wms-core": {
+                        "image": "korp/wms-core:pr579",
+                        "labels": {"korp.pr": "579"},
+                    }
+                }
+            },
+        }
+        with self.assertRaisesRegex(ValueError, "PR do caminho diverge"):
+            filters.index_active_overrides([override_file])
+
+    def test_replace_of_only_service_deletes_old_override(self):
+        current_content = {
+            "services": {
+                "wms-core": {
+                    "image": "korp/wms-core:pr579",
+                    "labels": {"korp.pr": "579"},
+                }
+            }
+        }
+        active, override_file = self.active_owners(current_content)
+        incoming = target("logistica#580", 580, "wms-core")
+        plan = filters.resolve_application([incoming], active, policy="replace")
+        self.assertEqual(plan["deletes"], [self.old_path])
+        self.assertEqual(
+            plan["writes"],
+            [{
+                "path": incoming["override_path"],
+                "content": {
+                    "services": {
+                        "wms-core": {
+                            "image": "korp/wms-core:pr580",
+                            "labels": {
+                                "korp.pr": "580",
+                                "korp.repositorio": "logistica",
+                            },
+                        }
+                    }
+                },
+            }],
+        )
+        self.assertEqual(override_file["content"], current_content)
+
+    def test_replace_rewrites_old_override_when_another_service_remains(self):
+        active, override_file = self.active_owners()
+        incoming = target("logistica#580", 580, "wms-core")
+        plan = filters.resolve_application([incoming], active, policy="replace")
+        writes = {write["path"]: write["content"] for write in plan["writes"]}
+        self.assertEqual(plan["deletes"], [])
+        self.assertEqual(
+            writes[self.old_path],
+            {"services": {"wms-gateway": self.current_content["services"]["wms-gateway"]}},
+        )
+        self.assertEqual(override_file["content"], self.current_content)
+
+    def test_groups_two_services_in_one_write_and_compose_run(self):
+        incoming = [
+            target("logistica#580", 580, "wms-core"),
+            target("logistica#580", 580, "wms-gateway"),
+        ]
+        plan = filters.resolve_application(incoming, {}, policy="fail")
+        self.assertEqual(
+            plan["writes"],
+            [{
+                "path": incoming[0]["override_path"],
+                "content": {
+                    "services": {
+                        "wms-core": {
+                            "image": "korp/wms-core:pr580",
+                            "labels": {
+                                "korp.pr": "580",
+                                "korp.repositorio": "logistica",
+                            },
+                        },
+                        "wms-gateway": {
+                            "image": "korp/wms-gateway:pr580",
+                            "labels": {
+                                "korp.pr": "580",
+                                "korp.repositorio": "logistica",
+                            },
+                        },
+                    }
+                },
+            }],
+        )
+        self.assertEqual(
+            plan["compose_runs"],
+            [{
+                "project_src": "/etc/korp/composes",
+                "files": [
+                    "logistica-compose.yml",
+                    "pr-overrides/pr580/logistica-compose.yml",
+                ],
+                "services": ["wms-core", "wms-gateway"],
+            }],
+        )
+
+    def test_keep_does_not_advance_simulated_owner(self):
+        active, _ = self.active_owners()
+        first = target("logistica#580", 580, "wms-core")
+        kept = target("logistica#581", 581, "wms-core")
+        plan = filters.resolve_application(
+            [first, kept],
+            active,
+            policy="ask",
+            decisions={first["target_id"]: "replace", kept["target_id"]: "keep"},
+        )
+        self.assertEqual(plan["apply_targets"], [first])
+        self.assertEqual(plan["skipped_targets"], [kept])
+        write_paths = [write["path"] for write in plan["writes"]]
+        self.assertIn(first["override_path"], write_paths)
+        self.assertNotIn(kept["override_path"], write_paths)
+
+    def test_replaced_batch_candidate_never_produces_a_write(self):
+        first = target("logistica#580", 580, "wms-core")
+        final = target("logistica#581", 581, "wms-core")
+        plan = filters.resolve_application([first, final], {}, policy="replace")
+        self.assertEqual(plan["apply_targets"], [final])
+        self.assertEqual(
+            [write["path"] for write in plan["writes"]],
+            [final["override_path"]],
+        )
+
+    def test_refresh_then_replace_removes_persisted_owner(self):
+        current_content = {
+            "services": {
+                "wms-core": {
+                    "image": "korp/wms-core:pr579",
+                    "labels": {"korp.pr": "579"},
+                }
+            }
+        }
+        active, _ = self.active_owners(current_content)
+        refresh = target("logistica#579", 579, "wms-core")
+        final = target("logistica#580", 580, "wms-core")
+        plan = filters.resolve_application([refresh, final], active, policy="replace")
+        self.assertEqual(plan["apply_targets"], [final])
+        self.assertEqual(plan["deletes"], [self.old_path])
+        self.assertEqual(
+            [write["path"] for write in plan["writes"]],
+            [final["override_path"]],
+        )
+
+    def test_invalid_or_missing_ask_decision_aborts(self):
+        active, _ = self.active_owners()
+        incoming = target("logistica#580", 580, "wms-core")
+        for decisions in ({}, {incoming["target_id"]: "invalid"}):
+            with self.subTest(decisions=decisions):
+                plan = filters.resolve_application(
+                    [incoming], active, policy="ask", decisions=decisions
+                )
+                self.assertFalse(plan["may_mutate"])
+                self.assertEqual(plan["compose_runs"], [])
+
+    def test_rejects_unknown_policy(self):
+        with self.assertRaisesRegex(ValueError, "Política de conflito inválida"):
+            filters.resolve_application([], {}, policy="unknown")

--- a/tests/unit/test_qa_pr_reset_role_yaml.py
+++ b/tests/unit/test_qa_pr_reset_role_yaml.py
@@ -1,0 +1,287 @@
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ROLE = ROOT / "roles/qa_pr_reset"
+PLAYBOOK = ROOT / "pr-reset-playbook.yml"
+TASK_FILES = ("main.yml", "read_override.yml", "reset_compose.yml")
+CONTROL_KEYS = {
+    "name",
+    "when",
+    "loop",
+    "loop_control",
+    "register",
+    "vars",
+    "tags",
+    "changed_when",
+    "failed_when",
+    "delegate_to",
+    "become",
+}
+
+
+def load_tasks(filename):
+    tasks = yaml.safe_load((ROLE / "tasks" / filename).read_text())
+    if not isinstance(tasks, list):
+        raise AssertionError(f"{filename} must contain a YAML task list")
+    return tasks
+
+
+def module_tasks(tasks, module):
+    return [task for task in tasks if module in task]
+
+
+def scalar_text(value):
+    if isinstance(value, dict):
+        return " ".join(
+            f"{key} {scalar_text(item)}" for key, item in value.items()
+        )
+    if isinstance(value, list):
+        return " ".join(scalar_text(item) for item in value)
+    return str(value)
+
+
+def module_names(tasks):
+    names = set()
+    for task in tasks:
+        names.update(set(task) - CONTROL_KEYS)
+        for block_name in ("block", "rescue", "always"):
+            block = task.get(block_name)
+            if isinstance(block, list):
+                names.update(module_names(block))
+    return names
+
+
+class QaPrResetRoleYamlTests(unittest.TestCase):
+    def test_every_required_role_yaml_loads(self):
+        for filename in TASK_FILES:
+            with self.subTest(filename=filename):
+                self.assertIsInstance(load_tasks(filename), list)
+
+    def test_reset_playbook_is_local_privileged_and_role_only(self):
+        plays = yaml.safe_load(PLAYBOOK.read_text())
+        self.assertEqual(len(plays), 1)
+        play = plays[0]
+
+        self.assertEqual(play["hosts"], "127.0.0.1")
+        self.assertEqual(play["connection"], "local")
+        self.assertIs(play["become"], True)
+        self.assertEqual(play["become_user"], "{{ linux_korp.user }}")
+        self.assertEqual(
+            play["vars"]["ansible_become_password"],
+            "{{ linux_korp.password }}",
+        )
+        self.assertEqual(play["roles"], ["qa_pr_reset"])
+        self.assertNotIn("ansible.builtin.import_playbook", play)
+
+        bootstrap_text = (ROOT / "setup.sh").read_text()
+        main_text = (ROOT / "main.yml").read_text()
+        for filename in ("pr-playbook.yml", "pr-reset-playbook.yml"):
+            self.assertNotIn(filename, bootstrap_text)
+            self.assertNotIn(filename, main_text)
+
+    def test_main_reads_and_validates_overrides_before_deleting_them(self):
+        tasks = load_tasks("main.yml")
+        read_index = next(
+            index
+            for index, task in enumerate(tasks)
+            if task.get("ansible.builtin.include_tasks") == "read_override.yml"
+        )
+        validate_override_index = next(
+            (
+                index
+                for index, task in enumerate(tasks)
+                if (
+                    "ansible.builtin.set_fact" in task
+                    and "qa_pr_index_active_overrides" in scalar_text(task)
+                )
+            ),
+            len(tasks),
+        )
+        stat_index = next(
+            index
+            for index, task in enumerate(tasks)
+            if "ansible.builtin.stat" in task
+        )
+        assert_index = next(
+            index
+            for index, task in enumerate(tasks)
+            if "ansible.builtin.assert" in task
+            and "qa_pr_reset_base_file.stat.exists" in scalar_text(task)
+        )
+        compose_check_index = next(
+            (
+                index
+                for index, task in enumerate(tasks)
+                if "community.docker.docker_compose_v2" in task
+            ),
+            len(tasks),
+        )
+        delete_index = next(
+            index
+            for index, task in enumerate(tasks)
+            if "ansible.builtin.file" in task
+        )
+        reset_index = next(
+            index
+            for index, task in enumerate(tasks)
+            if task.get("ansible.builtin.include_tasks") == "reset_compose.yml"
+        )
+
+        base_assert = tasks[assert_index]["ansible.builtin.assert"]
+        base_assert_checks_exists_and_isreg = all(
+            expression in base_assert["that"]
+            for expression in (
+                "qa_pr_reset_base_file.stat.exists | bool",
+                "qa_pr_reset_base_file.stat.isreg | bool",
+            )
+        )
+        compose_check_task = (
+            tasks[compose_check_index]
+            if compose_check_index < len(tasks)
+            else {}
+        )
+        compose_check_module = compose_check_task.get(
+            "community.docker.docker_compose_v2", {}
+        )
+
+        self.assertLess(read_index, validate_override_index)
+        self.assertLess(validate_override_index, stat_index)
+        self.assertLess(stat_index, assert_index)
+        self.assertLess(assert_index, compose_check_index)
+        self.assertLess(compose_check_index, delete_index)
+        self.assertLess(delete_index, reset_index)
+        self.assertTrue(base_assert_checks_exists_and_isreg)
+        self.assertTrue(compose_check_task["check_mode"])
+        self.assertEqual(
+            compose_check_module["files"],
+            ["{{ qa_pr_reset_run.compose_file }}"],
+        )
+
+    def test_override_read_builds_unique_base_compose_runs(self):
+        tasks = load_tasks("read_override.yml")
+        find_tasks = module_tasks(tasks, "ansible.builtin.find")
+        slurp_tasks = module_tasks(tasks, "ansible.builtin.slurp")
+        override_file_tasks = [
+            task
+            for task in module_tasks(tasks, "ansible.builtin.set_fact")
+            if "qa_pr_reset_override_files" in scalar_text(task)
+        ]
+        run_tasks = [
+            task
+            for task in module_tasks(tasks, "ansible.builtin.set_fact")
+            if "qa_pr_reset_runs" in scalar_text(task)
+        ]
+
+        self.assertEqual(len(find_tasks), 1)
+        self.assertEqual(len(slurp_tasks), 1)
+        self.assertEqual(len(override_file_tasks), 1)
+        self.assertEqual(len(run_tasks), 1)
+        self.assertEqual(find_tasks[0]["ansible.builtin.find"]["recurse"], True)
+        self.assertNotIn("patterns", find_tasks[0]["ansible.builtin.find"])
+        self.assertIn("/pr-overrides", scalar_text(find_tasks[0]))
+        self.assertIn(
+            "qa_pr_reset_found_overrides.files", scalar_text(slurp_tasks[0])
+        )
+        self.assertIn("qa_pr_reset_override.path", scalar_text(slurp_tasks[0]))
+
+        override_file_text = scalar_text(override_file_tasks[0])
+        self.assertIn("qa_pr_reset_project_src", override_file_text)
+        self.assertIn("qa_pr_reset_slurped_override.content", override_file_text)
+        self.assertIn("b64decode", override_file_text)
+        self.assertIn("from_yaml", override_file_text)
+
+        run_text = scalar_text(run_tasks[0])
+        self.assertIn("qa_pr_reset_project_src", run_text)
+        self.assertIn("basename", run_text)
+        self.assertIn("project_src", run_text)
+        self.assertIn("compose_file", run_text)
+        self.assertIn(
+            "not in qa_pr_reset_runs", scalar_text(run_tasks[0].get("when"))
+        )
+
+    def test_main_discovers_and_removes_all_installed_override_roots(self):
+        tasks = load_tasks("main.yml")
+        discoveries = module_tasks(tasks, "ansible.builtin.find")
+        self.assertEqual(len(discoveries), 1)
+        discovery = discoveries[0]["ansible.builtin.find"]
+        self.assertEqual(discovery["paths"], "{{ compose_dir_path }}")
+        self.assertEqual(discovery["patterns"], ["pr-overrides"])
+        self.assertEqual(discovery["file_type"], "directory")
+        self.assertTrue(discovery["recurse"])
+
+        deletions = module_tasks(tasks, "ansible.builtin.file")
+        self.assertEqual(len(deletions), 1)
+        deletion = deletions[0]
+        args = deletion["ansible.builtin.file"]
+
+        self.assertEqual(args["path"], "{{ qa_pr_reset_override_root }}")
+        self.assertEqual(args["state"], "absent")
+        self.assertIn("qa_pr_reset_override_roots", scalar_text(deletion["loop"]))
+        roots_text = scalar_text(tasks)
+        self.assertIn("compose_dir_path", roots_text)
+        self.assertIn("qa_pr_reset_found_override_roots.files", roots_text)
+        self.assertNotIn("versioned_compose_dir_path", roots_text)
+        self.assertGreaterEqual(roots_text.count("regex_replace"), 2)
+        self.assertIn("/pr-overrides", roots_text)
+        self.assertNotIn("qa_pr_reset_override.path", scalar_text(deletion))
+
+    def test_reset_reapplies_only_each_full_base_compose(self):
+        tasks = load_tasks("reset_compose.yml")
+        compose_tasks = module_tasks(
+            tasks, "community.docker.docker_compose_v2"
+        )
+        self.assertEqual(len(compose_tasks), 1)
+        args = compose_tasks[0]["community.docker.docker_compose_v2"]
+
+        self.assertEqual(
+            args["project_src"], "{{ qa_pr_reset_run.project_src }}/"
+        )
+        self.assertEqual(args["env_files"], ["{{ docker_env_file_path }}"])
+        self.assertEqual(args["files"], ["{{ qa_pr_reset_run.compose_file }}"])
+        for forbidden in (
+            "services",
+            "project_name",
+            "remove_orphans",
+            "pull",
+            "recreate",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, args)
+
+    def test_empty_environment_has_no_compose_runs(self):
+        main_tasks = load_tasks("main.yml")
+        reset_task = next(
+            task
+            for task in main_tasks
+            if task.get("ansible.builtin.include_tasks") == "reset_compose.yml"
+        )
+        initialization = next(
+            task
+            for task in main_tasks
+            if task.get("ansible.builtin.set_fact", {}).get(
+                "qa_pr_reset_runs"
+            )
+            == []
+        )
+
+        self.assertEqual(
+            initialization["ansible.builtin.set_fact"]["qa_pr_reset_runs"], []
+        )
+        self.assertIn("qa_pr_reset_runs", scalar_text(reset_task["loop"]))
+        compose_check_tasks = [
+            task
+            for task in main_tasks
+            if "community.docker.docker_compose_v2" in task
+        ]
+        self.assertEqual(len(compose_check_tasks), 1)
+        self.assertIn(
+            "qa_pr_reset_runs", scalar_text(compose_check_tasks[0]["loop"])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_qa_pr_role_yaml.py
+++ b/tests/unit/test_qa_pr_role_yaml.py
@@ -1,0 +1,453 @@
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ROLE = ROOT / "roles/qa_pr_apply"
+PLAYBOOK = ROOT / "pr-playbook.yml"
+ANSIBLE_LINT_CONFIG = ROOT / ".ansible-lint"
+DEFAULT_FILE = ROLE / "defaults/main.yml"
+OPERATIONS_GUIDE = ROOT / "docs/ambiente-qualidade-prs.md"
+TASK_FILES = (
+    "main.yml",
+    "load_pr.yml",
+    "load_report.yml",
+    "read_compose.yml",
+    "read_override.yml",
+    "prompt_conflict.yml",
+    "write_override.yml",
+    "apply_compose.yml",
+)
+CONTROL_KEYS = {
+    "name",
+    "when",
+    "loop",
+    "loop_control",
+    "register",
+    "vars",
+    "tags",
+    "changed_when",
+    "failed_when",
+    "delegate_to",
+    "become",
+}
+
+
+def load_yaml(path):
+    return yaml.safe_load(path.read_text())
+
+
+def load_tasks(filename):
+    tasks = load_yaml(ROLE / "tasks" / filename)
+    if not isinstance(tasks, list):
+        raise AssertionError(f"{filename} must contain a YAML task list")
+    return tasks
+
+
+def module_tasks(tasks, module):
+    return [task for task in tasks if module in task]
+
+
+def scalar_text(value):
+    if isinstance(value, dict):
+        return " ".join(
+            f"{key} {scalar_text(item)}" for key, item in value.items()
+        )
+    if isinstance(value, list):
+        return " ".join(scalar_text(item) for item in value)
+    return str(value)
+
+
+def module_names(tasks):
+    names = set()
+    for task in tasks:
+        names.update(set(task) - CONTROL_KEYS)
+        for block_name in ("block", "rescue", "always"):
+            block = task.get(block_name)
+            if isinstance(block, list):
+                names.update(module_names(block))
+    return names
+
+
+class QaPrRoleYamlTests(unittest.TestCase):
+    def test_every_required_role_yaml_loads(self):
+        self.assertIsInstance(load_yaml(DEFAULT_FILE), dict)
+        for filename in TASK_FILES:
+            with self.subTest(filename=filename):
+                self.assertIsInstance(load_tasks(filename), list)
+
+    def test_apply_playbook_is_local_privileged_and_role_only(self):
+        plays = load_yaml(PLAYBOOK)
+        self.assertEqual(len(plays), 1)
+        play = plays[0]
+
+        self.assertEqual(play["hosts"], "127.0.0.1")
+        self.assertEqual(play["connection"], "local")
+        self.assertIs(play["become"], True)
+        self.assertEqual(play["become_user"], "{{ linux_korp.user }}")
+        self.assertEqual(
+            play["vars"]["ansible_become_password"],
+            "{{ linux_korp.password }}",
+        )
+        self.assertEqual(play["roles"], ["qa_pr_apply"])
+        self.assertNotIn("ansible.builtin.import_playbook", play)
+
+        bootstrap_text = (ROOT / "setup.sh").read_text()
+        main_text = (ROOT / "main.yml").read_text()
+        for filename in ("pr-playbook.yml", "pr-reset-playbook.yml"):
+            self.assertNotIn(filename, bootstrap_text)
+            self.assertNotIn(filename, main_text)
+
+    def test_ansible_lint_has_only_the_qa_pr_exception_and_context(self):
+        config = load_yaml(ANSIBLE_LINT_CONFIG)
+
+        self.assertEqual(
+            config["skip_list"],
+            ["var-naming[no-role-prefix]"],
+        )
+        self.assertEqual(
+            config["extra_vars"],
+            {
+                "compose_dir_path": "/tmp/qa-pr-composes",
+                "versioned_compose_dir_path": "/tmp/qa-pr-versioned-composes",
+            },
+        )
+
+    def test_defaults_expose_minio_and_conflict_interfaces(self):
+        defaults = load_yaml(DEFAULT_FILE)
+        self.assertEqual(
+            defaults["qa_pr_minio_api"],
+            "https://minio-interno-api.korp.com.br",
+        )
+        self.assertEqual(defaults["qa_pr_minio_bucket"], "qa-prs")
+        self.assertEqual(
+            defaults["qa_pr_harbor_api"],
+            "https://harbor.korp.com.br/api/v2.0",
+        )
+        self.assertEqual(
+            defaults["qa_pr_harbor_registry"],
+            "harbor.korp.com.br",
+        )
+        self.assertEqual(defaults["qa_pr_harbor_project"], "qa-prs")
+        self.assertEqual(defaults["pr_conflict_policy"], "ask")
+        self.assertEqual(defaults["qa_pr_reports"], [])
+        self.assertEqual(defaults["qa_pr_compose_files"], [])
+        self.assertEqual(defaults["qa_pr_override_files"], [])
+        self.assertEqual(defaults["qa_pr_conflict_decisions"], {})
+
+    def test_main_normalizes_and_validates_inputs_before_external_work(self):
+        tasks = load_tasks("main.yml")
+        normalize_index = next(
+            index
+            for index, task in enumerate(tasks)
+            if "qa_pr_normalize_links" in scalar_text(
+                task.get("ansible.builtin.set_fact", {})
+            )
+        )
+        policy_index = next(
+            index
+            for index, task in enumerate(tasks)
+            if "ansible.builtin.assert" in task
+            and "pr_conflict_policy" in scalar_text(task)
+        )
+        load_index = next(
+            index
+            for index, task in enumerate(tasks)
+            if task.get("ansible.builtin.include_tasks") == "load_pr.yml"
+        )
+        first_direct_effect = min(
+            (
+                index
+                for index, task in enumerate(tasks)
+                if set(task)
+                & {
+                    "ansible.builtin.uri",
+                    "ansible.builtin.file",
+                    "ansible.builtin.copy",
+                    "community.docker.docker_compose_v2",
+                }
+            ),
+            default=len(tasks),
+        )
+        self.assertEqual(normalize_index, 0)
+        self.assertLess(normalize_index, policy_index)
+        self.assertLess(policy_index, load_index)
+        self.assertLess(normalize_index, first_direct_effect)
+
+    def test_minio_reads_are_anonymous_https_gets_with_tls_validation(self):
+        load_pr_tasks = load_tasks("load_pr.yml")
+        load_report_tasks = load_tasks("load_report.yml")
+        listing = module_tasks(load_pr_tasks, "ansible.builtin.uri")
+        report_requests = module_tasks(
+            load_report_tasks, "ansible.builtin.uri"
+        )
+        objects = [
+            task for task in report_requests
+            if task.get("register") == "qa_pr_minio_report"
+        ]
+        harbor = [
+            task for task in report_requests
+            if task.get("register") == "qa_pr_harbor_artifact"
+        ]
+        self.assertEqual(len(listing), 1)
+        self.assertEqual(len(objects), 1)
+        self.assertEqual(len(harbor), 1)
+
+        listing_args = listing[0]["ansible.builtin.uri"]
+        object_args = objects[0]["ansible.builtin.uri"]
+        for args in (listing_args, object_args):
+            self.assertEqual(args["method"], "GET")
+            self.assertIs(args["return_content"], True)
+            self.assertIs(args["validate_certs"], True)
+            self.assertTrue(str(args["url"]).startswith("{{ qa_pr_minio_api }}"))
+            self.assertNotIn("headers", args)
+            self.assertNotIn("url_username", args)
+            self.assertNotIn("url_password", args)
+
+        self.assertIn("/?list-type=2&prefix=", listing_args["url"])
+        self.assertIn("qa_pr_minio_prefix", listing_args["url"])
+        self.assertIn("qa_pr_report_key", object_args["url"])
+        self.assertIn("qa_pr_parse_minio_listing", scalar_text(load_pr_tasks))
+        self.assertIn(
+            "qa_pr_report_key | urlencode", object_args["url"]
+        )
+        harbor_args = harbor[0]["ansible.builtin.uri"]
+        self.assertEqual(harbor_args["method"], "GET")
+        self.assertIs(harbor_args["validate_certs"], True)
+        self.assertEqual(harbor_args["status_code"], [200, 404])
+        self.assertTrue(
+            str(harbor_args["url"]).startswith("{{ qa_pr_harbor_api }}")
+        )
+        self.assertIn("qa_pr_harbor_project | urlencode", harbor_args["url"])
+        self.assertIn(
+            "qa_pr_loaded_report.servico | urlencode",
+            harbor_args["url"],
+        )
+        self.assertIn(
+            "qa_pr_loaded_report.tag | urlencode",
+            harbor_args["url"],
+        )
+        self.assertNotIn("headers", harbor_args)
+        self.assertNotIn("url_username", harbor_args)
+        self.assertNotIn("url_password", harbor_args)
+        self.assertIn("qa_pr_load_report", scalar_text(load_report_tasks))
+        self.assertIn(
+            "qa_pr_resolve_registry_image",
+            scalar_text(load_report_tasks),
+        )
+        self.assertIn("qa_pr_reports", scalar_text(load_report_tasks))
+
+        report_includes = module_tasks(
+            load_pr_tasks, "ansible.builtin.include_tasks"
+        )
+        self.assertEqual(
+            [task["ansible.builtin.include_tasks"] for task in report_includes],
+            ["load_report.yml"],
+        )
+        self.assertIn("qa_pr_minio_keys", scalar_text(report_includes[0]))
+        missing_report_asserts = module_tasks(
+            load_pr_tasks, "ansible.builtin.assert"
+        )
+        self.assertTrue(missing_report_asserts)
+        self.assertIn("JSON", scalar_text(missing_report_asserts))
+
+    def test_base_and_override_discovery_stay_separate(self):
+        compose_tasks = load_tasks("read_compose.yml")
+        override_tasks = load_tasks("read_override.yml")
+
+        compose_find = module_tasks(compose_tasks, "ansible.builtin.find")
+        override_find = module_tasks(override_tasks, "ansible.builtin.find")
+        self.assertEqual(len(compose_find), 1)
+        self.assertEqual(len(override_find), 1)
+        self.assertIs(
+            compose_find[0]["ansible.builtin.find"]["recurse"], False
+        )
+        self.assertEqual(
+            compose_find[0]["ansible.builtin.find"]["patterns"],
+            ["*-compose.yml"],
+        )
+        self.assertIs(
+            override_find[0]["ansible.builtin.find"]["recurse"], True
+        )
+        self.assertIn(
+            "/pr-overrides",
+            str(override_find[0]["ansible.builtin.find"]["paths"]),
+        )
+
+        self.assertTrue(
+            module_tasks(compose_tasks, "ansible.builtin.slurp")
+        )
+        self.assertTrue(
+            module_tasks(override_tasks, "ansible.builtin.slurp")
+        )
+        self.assertIn("b64decode", scalar_text(compose_tasks))
+        self.assertIn("from_yaml", scalar_text(compose_tasks))
+        self.assertIn("qa_pr_compose_files", scalar_text(compose_tasks))
+        self.assertNotIn("qa_pr_override_files", scalar_text(compose_tasks))
+        self.assertIn("qa_pr_compose_file.path", scalar_text(compose_tasks))
+        self.assertNotIn(
+            "qa_pr_slurped_compose.item", scalar_text(compose_tasks)
+        )
+        self.assertIn("b64decode", scalar_text(override_tasks))
+        self.assertIn("from_yaml", scalar_text(override_tasks))
+        self.assertIn("qa_pr_override_files", scalar_text(override_tasks))
+        self.assertNotIn("qa_pr_compose_files", scalar_text(override_tasks))
+        self.assertIn("qa_pr_override_file.path", scalar_text(override_tasks))
+        override_accumulator = next(
+            task
+            for task in module_tasks(
+                override_tasks, "ansible.builtin.set_fact"
+            )
+            if "qa_pr_override_files" in scalar_text(task)
+        )
+        self.assertIn(
+            "qa_pr_project_src",
+            scalar_text(override_accumulator["ansible.builtin.set_fact"]),
+        )
+        self.assertNotIn(
+            "qa_pr_slurped_override.item", scalar_text(override_tasks)
+        )
+
+        main_text = scalar_text(load_tasks("main.yml"))
+        self.assertIn("compose_dir_path", main_text)
+        self.assertIn("qa_pr_select_report_version", main_text)
+        self.assertIn("qa_pr_selected_version", main_text)
+        self.assertIn("qa_pr_versioned_compose_dir", main_text)
+        self.assertIn("regex_replace", main_text)
+        self.assertIn("qa_pr_build_targets", main_text)
+        self.assertIn("qa_pr_compose_files", main_text)
+        self.assertIn("qa_pr_index_active_overrides", main_text)
+        self.assertIn("qa_pr_override_files", main_text)
+
+    def test_ask_resolves_all_decisions_before_any_mutation(self):
+        tasks = load_tasks("main.yml")
+        prompt_index, prompt_task = next(
+            (index, task)
+            for index, task in enumerate(tasks)
+            if task.get("ansible.builtin.include_tasks")
+            == "prompt_conflict.yml"
+        )
+        plan_index = next(
+            index
+            for index, task in enumerate(tasks)
+            if "qa_pr_resolve_application" in scalar_text(
+                task.get("ansible.builtin.set_fact", {})
+            )
+        )
+        gate_index = next(
+            index
+            for index, task in enumerate(tasks)
+            if "ansible.builtin.assert" in task
+            and "may_mutate" in scalar_text(task)
+        )
+        mutation_indices = [
+            index
+            for index, task in enumerate(tasks)
+            if (
+                "ansible.builtin.file" in task
+                or task.get("ansible.builtin.include_tasks")
+                in {"write_override.yml", "apply_compose.yml"}
+            )
+        ]
+        self.assertIn("qa_pr_targets", scalar_text(prompt_task["loop"]))
+        self.assertIn("pr_conflict_policy", scalar_text(prompt_task["when"]))
+        self.assertLess(prompt_index, plan_index)
+        self.assertLess(plan_index, gate_index)
+        self.assertTrue(mutation_indices)
+        self.assertLess(gate_index, min(mutation_indices))
+
+    def test_prompt_recalculates_and_defaults_nonaccepted_input_to_abort(self):
+        tasks = load_tasks("prompt_conflict.yml")
+        self.assertIn("qa_pr_detect_conflicts", scalar_text(tasks))
+        pauses = module_tasks(tasks, "ansible.builtin.pause")
+        self.assertEqual(len(pauses), 1)
+        prompt_text = scalar_text(pauses[0])
+        for field in ("current", "incoming", "pr_key", "service", "compose"):
+            self.assertIn(field, prompt_text)
+        self.assertIn("qa_pr_prompt_target", scalar_text(pauses[0]["when"]))
+
+        decisions = [
+            task
+            for task in module_tasks(tasks, "ansible.builtin.set_fact")
+            if "qa_pr_conflict_decisions"
+            in task["ansible.builtin.set_fact"]
+        ]
+        self.assertEqual(len(decisions), 1)
+        decision_text = scalar_text(decisions[0])
+        self.assertIn("user_input", decision_text)
+        self.assertIn("default('abort')", decision_text)
+        self.assertIn("lower", decision_text)
+        self.assertIn("trim", decision_text)
+        self.assertIn("replace", decision_text)
+        self.assertIn("keep", decision_text)
+        self.assertIn("abort", decision_text)
+        self.assertFalse(
+            module_names(tasks)
+            & {
+                "ansible.builtin.file",
+                "ansible.builtin.copy",
+                "community.docker.docker_compose_v2",
+            }
+        )
+
+    def test_override_write_uses_only_the_pure_execution_plan(self):
+        tasks = load_tasks("write_override.yml")
+        directories = module_tasks(tasks, "ansible.builtin.file")
+        copies = module_tasks(tasks, "ansible.builtin.copy")
+        self.assertEqual(len(directories), 1)
+        self.assertEqual(len(copies), 1)
+        directory = directories[0]["ansible.builtin.file"]
+        self.assertEqual(directory["state"], "directory")
+        self.assertEqual(str(directory["mode"]), "0755")
+        self.assertIn("dirname", str(directory["path"]))
+        copy_args = copies[0]["ansible.builtin.copy"]
+        self.assertIn("qa_pr_override_write.path", str(copy_args["dest"]))
+        self.assertIn(
+            "qa_pr_override_write.content", str(copy_args["content"])
+        )
+        self.assertIn("to_nice_yaml", str(copy_args["content"]))
+
+    def test_compose_run_is_targeted_and_uses_expected_files(self):
+        tasks = load_tasks("apply_compose.yml")
+        compose_tasks = module_tasks(
+            tasks, "community.docker.docker_compose_v2"
+        )
+        self.assertEqual(len(compose_tasks), 1)
+        args = compose_tasks[0]["community.docker.docker_compose_v2"]
+        self.assertEqual(
+            args["project_src"], "{{ qa_pr_compose_run.project_src }}/"
+        )
+        self.assertEqual(args["env_files"], ["{{ docker_env_file_path }}"])
+        self.assertEqual(args["files"], "{{ qa_pr_compose_run.files }}")
+        self.assertEqual(
+            args["services"], "{{ qa_pr_compose_run.services }}"
+        )
+        for forbidden in (
+            "project_name",
+            "remove_orphans",
+            "pull",
+            "recreate",
+        ):
+            self.assertNotIn(forbidden, args)
+
+    def test_role_never_uses_credentialed_clients_or_setup_script(self):
+        documents = [load_yaml(DEFAULT_FILE)]
+        documents.extend(load_tasks(filename) for filename in TASK_FILES)
+        text = scalar_text(documents).lower()
+        for forbidden in ("mc ", "aws ", "boto3", "setup.sh"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, text)
+
+    def test_operations_guide_warns_about_final_customer_environments(self):
+        guide = OPERATIONS_GUIDE.read_text()
+        self.assertIn("ambiente de cliente final", guide)
+        self.assertIn("`<repositorio>#<N>`", guide)
+        self.assertIn("`korp.pr`", guide)
+        self.assertIn("`korp.repositorio`", guide)
+        self.assertIn("repositórios diferentes", guide)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objetivo

Formaliza no KorpSetupLinux o runtime para aplicar, consultar e resetar imagens de Pull Requests nos ambientes de QA.

## Inclui

- CLI `qa-pr` para doctor, apply, status e reset;
- playbooks e roles idempotentes para criação e remoção de overrides de PR;
- resolução da versão a partir dos relatórios publicados no MinIO;
- isolamento de conflitos por repositório e validação antes de mutações;
- testes unitários, fixtures e documentação operacional.

## Escopo

Este PR apenas disponibiliza o runtime oficial no KorpSetupLinux. A etapa do AWX que garante sua implantação em cada QA será tratada separadamente.

## Validações

- `bash -n qa-pr`;
- `./qa-pr --help`;
- `python3 -m compileall -q filter_plugins tests/unit`;
- `git diff --check`.

Os testes com `pytest` e o `ansible-lint` não foram executados localmente porque as ferramentas não estão instaladas neste ambiente.