### PR TITLE
login e portal deixam de ser versionados (2024.2)

### DIFF
--- a/roles/infrastructure-web/templates/composes/2024.2.0/infrastructure-web-compose.yml.j2
+++ b/roles/infrastructure-web/templates/composes/2024.2.0/infrastructure-web-compose.yml.j2
@@ -18,40 +18,6 @@ networks:
       name: servicos
 
 services:
-  login-2024-2-0:
-    image: "{{ docker_account }}/viasoft.authentication-frontend:2024.2.0.x{{ docker_image_suffix }}"
-    container_name: "login-2024.2.0"
-    restart: unless-stopped
-    extra_hosts: *default-extra_hosts
-    environment:
-      - ON_PREMISE_MODE=true
-      - USE_SERVERGC=$USE_SERVERGC
-      - GATEWAY_URL={{ frontend.endpoints.gateway_url }}
-      - CDN_URL={{ frontend.endpoints.cdn_url }}
-      - FRONTEND_URL={{ frontend.endpoints.frontend_url }}
-      - CERT_FILE_PATH={{ containers_cert_path }}
-    networks:
-      - servicos
-    volumes:
-      - "{{ certs_directory }}/:{{ certs_directory }}/"
-
-  portal-2024-2-0:
-    image: "{{ docker_account }}/viasoft.portal-frontend:2024.2.0.x{{ docker_image_suffix }}"
-    container_name: "portal-2024.2.0"
-    restart: unless-stopped
-    extra_hosts: *default-extra_hosts
-    environment:
-      - ON_PREMISE_MODE=true
-      - USE_SERVERGC=$USE_SERVERGC
-      - GATEWAY_URL={{ frontend.endpoints.gateway_url }}
-      - CDN_URL={{ frontend.endpoints.cdn_url }}
-      - FRONTEND_URL={{ frontend.endpoints.frontend_url }}
-      - CERT_FILE_PATH={{ containers_cert_path }}
-    volumes:
-      - "{{ certs_directory }}/:{{ certs_directory }}/"
-    networks:
-      - servicos
-
   ADM01-2024-2-0:
     image: "{{ docker_account }}/viasoft.administration-frontend:2024.2.0.x{{ docker_image_suffix }}"
     container_name: "ADM01-2024.2.0"

--- a/roles/infrastructure-web/templates/composes/infrastructure-web-compose.yml.j2
+++ b/roles/infrastructure-web/templates/composes/infrastructure-web-compose.yml.j2
@@ -328,6 +328,51 @@ services:
     networks:
       - servicos
 
+  # login e portal carregam antes da autenticação, quando ainda não há tenant e portanto não há
+  # versão de ambiente para escolher. Por isso são exclusivos: uma única versão por instalação.
+  # O nome do serviço é fixo para que o compose substitua o container no upgrade, em vez de
+  # acumular um container por versão.
+  login:
+    image: "{{ docker_account }}/viasoft.authentication-frontend:{{ version_without_build }}.x{{ docker_image_suffix }}"
+    container_name: "login-{{ version_without_build }}"
+    restart: unless-stopped
+    extra_hosts: *default-extra_hosts
+    environment:
+      - ON_PREMISE_MODE=true
+      - USE_SERVERGC=$USE_SERVERGC
+      - GATEWAY_URL={{ frontend.endpoints.gateway_url }}
+      - CDN_URL={{ frontend.endpoints.cdn_url }}
+      - FRONTEND_URL={{ frontend.endpoints.frontend_url }}
+      - CERT_FILE_PATH={{ containers_cert_path }}
+    networks:
+      servicos:
+        # o Korp.Legacy.Frontend-router resolve o container como <identificador>-<major com hifens>
+        aliases:
+          - "login-{{ version_without_build | replace('.', '-') }}"
+    volumes:
+      - "{{ certs_directory }}/:{{ certs_directory }}/"
+
+  portal-frontend:
+    image: "{{ docker_account }}/viasoft.portal-frontend:{{ version_without_build }}.x{{ docker_image_suffix }}"
+    container_name: "portal-{{ version_without_build }}"
+    restart: unless-stopped
+    extra_hosts: *default-extra_hosts
+    depends_on:
+      - viasoft-portal
+    environment:
+      - ON_PREMISE_MODE=true
+      - USE_SERVERGC=$USE_SERVERGC
+      - GATEWAY_URL={{ frontend.endpoints.gateway_url }}
+      - CDN_URL={{ frontend.endpoints.cdn_url }}
+      - FRONTEND_URL={{ frontend.endpoints.frontend_url }}
+      - CERT_FILE_PATH={{ containers_cert_path }}
+    volumes:
+      - "{{ certs_directory }}/:{{ certs_directory }}/"
+    networks:
+      servicos:
+        aliases:
+          - "portal-{{ version_without_build | replace('.', '-') }}"
+
 
 
 


### PR DESCRIPTION
Backport de #571 para `release/2024.2.0.x`.

## Contexto

`login` e `portal` carregam **antes da autenticação**, quando ainda não existe tenant e portanto não existe versão de ambiente (`DesktopDatabaseVersion`) para escolher. Versioná-los criou linhas concorrentes em `PortalApplicationVersions`, e o `Viasoft.Portal` passou a decidir qual servir pelo fallback `ORDER BY ReleaseDate DESC` — que, na prática, elegia **o container que reiniciou por último**.

Como o role não remove os containers de versões anteriores, o `login-2024.2.0` seguia de pé com `restart: unless-stopped` e se re-registrava a cada reboot, servindo o bundle antigo num ambiente novo.

## O que muda

- `login` e `portal-frontend` voltam para o compose base (`infrastructure-web-compose.yml.j2`), exclusivos: uma versão por instalação.
- Removidos os serviços `login-*` e `portal-*` de `2024.2.0/`. `ADM01` e `REL01` seguem versionados.
- **Chave de serviço fixa** (`login`, `portal-frontend`): no upgrade o compose substitui o container em vez de deixá-lo órfão. Era a chave versionada que causava o acúmulo.
- **Alias de rede** `<identificador>-<major com hifens>`: o `korp.legacy.frontend-router` resolve o container a partir da URL do CDN nesse formato (`main.go:163-188`), então o nome que ele espera continua resolvendo.
- `container_name` segue `login-{{ version_without_build }}`, igual ao atual no `docker ps`.
- `depends_on: viasoft-portal` no `portal-frontend`, possível agora que ele está no mesmo arquivo do backend.

## Validação

YAML dos arquivos alterados parseia (Jinja renderizado com placeholders).

## Pendências (fora deste PR)

1. `specs.md` §5 marca frontend na raiz de `composes/` como inválido, então `login` e `portal-frontend` aparecem como exclusivos inválidos no validador. A correção natural é incluí-los na tabela de exceção do §9 (que já existe para `korp.legacy.frontend-router` e `viasoft.loader`).
2. Hosts que já rodam `login-2024.2.0` ficam com esse container órfão — o role não tem `remove_orphans` nem remoção explícita. Precisa de limpeza do container e das linhas correspondentes em `PortalApplicationVersions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)